### PR TITLE
docs(web): add playground PR examples to documentation

### DIFF
--- a/packages/web/src/content/docs/docs/ci/github-actions.md
+++ b/packages/web/src/content/docs/docs/ci/github-actions.md
@@ -174,6 +174,10 @@ The `issue_comment` trigger fires for all PR comments. The `if` guard ensures th
 Use `open-pr: 'true'` if you want a model PR on every analysis run. Use `open-pr: 'auto'` with the workflow above if you prefer on-demand creation.
 :::
 
+:::tip[See it in action]
+[Playground PR #3](https://github.com/erode-app/playground/pull/3) demonstrates the full flow. The PR adds a new dependency and a new component. Erode detects both, a reviewer replies `/erode update-model`, and Erode creates a [model update PR](https://github.com/erode-app/playground-models-only/pull/2) with the proposed relationship and component additions.
+:::
+
 ## PR comments
 
 After analysis, Erode posts a comment on the pull request containing:

--- a/packages/web/src/content/docs/docs/getting-started.md
+++ b/packages/web/src/content/docs/docs/getting-started.md
@@ -44,12 +44,27 @@ Erode runs on every PR and posts a comment listing any undeclared dependencies, 
 
 ## Try the example project
 
-The [playground repository](https://github.com/erode-app/playground) is a ready-made example you can fork and use to try Erode. It contains a multi-service architecture (frontend, API gateway, microservices, database) with a LikeC4 model and a pre-configured GitHub Actions workflow.
+The [playground repository](https://github.com/erode-app/playground) is a ready-made example you can fork and use to try Erode. It contains a multi-service architecture (frontend, API gateway, microservices, database) with pre-configured GitHub Actions workflows for both LikeC4 and Structurizr models.
+
+To try it yourself:
 
 1. [Fork the repository](https://github.com/erode-app/playground/fork)
 2. Add your `GEMINI_API_KEY` (or another [AI provider](/docs/reference/ai-providers/) key) as a repository secret
-3. Open a PR that introduces an undeclared dependency. For example, make the frontend call `user-service` directly instead of going through `api-gateway`
-4. Erode will comment on the PR with the detected finding
+3. Open a PR that introduces an undeclared dependency
+
+Or browse the existing example PRs to see Erode's output without any setup:
+
+### Undeclared dependency (LikeC4)
+
+[PR #1: feat: add admin users page](https://github.com/erode-app/playground/pull/1) adds a frontend page that calls `user_service` directly, bypassing the `api_gateway`. The architecture model declares that the frontend depends on the gateway, not the service behind it. Erode detects this undeclared dependency and reports the violation on the PR.
+
+### Undeclared dependency (Structurizr)
+
+[PR #2: feat: add admin users page](https://github.com/erode-app/playground/pull/2) introduces the same violation as PR #1, but the analysis runs against a Structurizr workspace instead of a LikeC4 model. The result is the same finding, showing that Erode works across model formats.
+
+### New component and model update
+
+[PR #3: feat: enrich products with creator info](https://github.com/erode-app/playground/pull/3) adds a `product_service → user_service` dependency and introduces a new `order_service`. Erode detects the undeclared dependency, auto-detects the new component, and after a reviewer replies `/erode update-model`, creates a [model update PR](https://github.com/erode-app/playground-models-only/pull/2) with the proposed changes.
 
 ## What's next
 

--- a/packages/web/src/content/docs/docs/models/likec4.md
+++ b/packages/web/src/content/docs/docs/models/likec4.md
@@ -6,7 +6,7 @@ description: Write the architecture model that Erode reads.
 Erode reads a LikeC4 architecture model to understand your system's intended structure. It compares pull request changes against this model to detect drift.
 
 :::tip[See it in action]
-Check out the [playground example PR](https://github.com/erode-app/playground/pull/1) to see Erode analyzing a LikeC4 model.
+[Playground PR #1](https://github.com/erode-app/playground/pull/1) adds a frontend page that calls `user_service` directly, bypassing the `api_gateway`. Erode analyzes the PR against the LikeC4 model, detects the undeclared dependency, and posts the finding as a PR comment.
 :::
 
 ## What is LikeC4

--- a/packages/web/src/content/docs/docs/models/structurizr.md
+++ b/packages/web/src/content/docs/docs/models/structurizr.md
@@ -14,7 +14,7 @@ Structurizr support is new and under active development. If you are starting fre
 :::
 
 :::tip[See it in action]
-Check out the [playground example PR](https://github.com/erode-app/playground/pull/2) to see Erode analyzing a Structurizr workspace.
+[Playground PR #2](https://github.com/erode-app/playground/pull/2) introduces the same violation as the [LikeC4 example](/docs/models/likec4/), but analyzed against a Structurizr workspace. The frontend calls `user_service` directly instead of going through `api_gateway`, and Erode detects the undeclared dependency the same way.
 :::
 
 ## What is Structurizr


### PR DESCRIPTION
## Summary

- Expanded the "Try the example project" section in getting-started with descriptions of all three playground PRs ([erode-app/playground#1](https://github.com/erode-app/playground/pull/1) undeclared dep with LikeC4, [erode-app/playground#2](https://github.com/erode-app/playground/pull/2) same with Structurizr, [erode-app/playground#3](https://github.com/erode-app/playground/pull/3) new component + model update flow)
- Replaced generic "See it in action" tips in the LikeC4 and Structurizr model pages with concrete descriptions of what each PR demonstrates
- Added a "See it in action" tip to the GitHub Actions model update PRs section, linking [erode-app/playground#3](https://github.com/erode-app/playground/pull/3) and its resulting [model update PR](https://github.com/erode-app/playground-models-only/pull/2)

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint:md` passes
- [x] Verify rendered pages with `npm run dev:web`