### PR TITLE
fix(core): handle 403 on locked PR conversations gracefully

### DIFF
--- a/packages/core/src/pipelines/publish.ts
+++ b/packages/core/src/pipelines/publish.ts
@@ -156,9 +156,11 @@ export async function publishResults(
         p.succeed('No findings — old comment cleared (if any)');
       }
     } catch (error) {
-      p.warn(
-        `Could not publish PR comment: ${error instanceof Error ? error.message : String(error)}`
-      );
+      const message = error instanceof Error ? error.message : String(error);
+      p.warn(`Could not publish PR comment: ${message}`);
+      if (options.githubActions) {
+        console.warn(`::warning::Could not publish PR comment: ${message}`);
+      }
     }
   }
 

--- a/packages/core/src/platforms/github/__tests__/writer.test.ts
+++ b/packages/core/src/platforms/github/__tests__/writer.test.ts
@@ -228,6 +228,30 @@ describe('GitHubWriter', () => {
       expect(err).toBeInstanceOf(ApiError);
       expect((err as ApiError).statusCode).toBe(502);
     });
+
+    it('should throw ErodeError with IO_PERMISSION_DENIED on 403', async () => {
+      const error403 = Object.assign(new Error('Resource not accessible by integration'), {
+        status: 403,
+      });
+      mockIssuesCreateComment.mockRejectedValue(error403);
+      const ref = makeRef();
+
+      const err = await writer.commentOnChangeRequest(ref, 'test').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ErodeError);
+      expect((err as ErodeError).code).toBe(ErrorCode.IO_PERMISSION_DENIED);
+    });
+
+    it('should not retry on 403 error', async () => {
+      const error403 = Object.assign(new Error('Resource not accessible by integration'), {
+        status: 403,
+      });
+      mockIssuesCreateComment.mockRejectedValue(error403);
+      const ref = makeRef();
+
+      await writer.commentOnChangeRequest(ref, 'test').catch((_e: unknown) => _e);
+
+      expect(mockIssuesCreateComment).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('deleteComment', () => {
@@ -247,6 +271,21 @@ describe('GitHubWriter', () => {
         repo: 'repo',
         comment_id: 5,
       });
+    });
+
+    it('should throw ErodeError with IO_PERMISSION_DENIED on 403', async () => {
+      const error403 = Object.assign(new Error('Resource not accessible by integration'), {
+        status: 403,
+      });
+      mockIssuesListComments.mockResolvedValue({
+        data: [{ id: 5, body: '<!-- marker -->' }],
+      });
+      mockIssuesDeleteComment.mockRejectedValue(error403);
+      const ref = makeRef();
+
+      const err = await writer.deleteComment(ref, '<!-- marker -->').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ErodeError);
+      expect((err as ErodeError).code).toBe(ErrorCode.IO_PERMISSION_DENIED);
     });
   });
 });

--- a/packages/core/src/platforms/github/writer.ts
+++ b/packages/core/src/platforms/github/writer.ts
@@ -9,6 +9,18 @@ import type {
   CreateOrUpdateChangeRequestOptions,
 } from '../source-platform.js';
 import { wrapPlatformError, isTransientError } from '../platform-utils.js';
+import { extractStatusCode } from '../../utils/error-utils.js';
+
+function throw403AsPermissionError(error: unknown, prNumber: number): void {
+  if (error instanceof Error && extractStatusCode(error) === 403) {
+    throw new ErodeError(
+      'Cannot comment on PR: the conversation may be locked or the token lacks write access',
+      ErrorCode.IO_PERMISSION_DENIED,
+      'Cannot comment on PR. Check if the conversation is locked or if the token has issues:write permission.',
+      { prNumber }
+    );
+  }
+}
 
 export class GitHubWriter implements SourcePlatformWriter {
   private readonly octokit: Octokit;
@@ -190,6 +202,7 @@ export class GitHubWriter implements SourcePlatformWriter {
         { retries: 1, initialDelay: 2000, shouldRetry: isTransientError }
       );
     } catch (error) {
+      throw403AsPermissionError(error, ref.number);
       wrapPlatformError(error, 'github', 'Could not comment on pull request');
     }
   }
@@ -209,6 +222,7 @@ export class GitHubWriter implements SourcePlatformWriter {
         { retries: 1, initialDelay: 2000, shouldRetry: isTransientError }
       );
     } catch (error) {
+      throw403AsPermissionError(error, ref.number);
       wrapPlatformError(error, 'github', 'Could not remove comment from pull request');
     }
   }


### PR DESCRIPTION
## Summary

- Detect 403 errors in `GitHubWriter.commentOnChangeRequest` and `deleteComment`, throwing a descriptive `ErodeError` with `IO_PERMISSION_DENIED` that mentions locked conversations and token permissions as possible causes
- Emit a `::warning::` GitHub Actions annotation when PR commenting fails in CI mode, so failures surface as yellow annotations instead of being silently swallowed by `SilentProgress`
- Add tests verifying 403 produces `IO_PERMISSION_DENIED` and is not retried

Fixes the issue hit on [playground PR #2](https://github.com/erode-app/playground/actions/runs/22624378958/job/65557099200?pr=2) where the locked conversation caused an unhelpful generic error that was invisible in CI.

## Test plan

- [x] `commentOnChangeRequest` with 403 throws `ErodeError` with `IO_PERMISSION_DENIED`
- [x] `deleteComment` with 403 throws `ErodeError` with `IO_PERMISSION_DENIED`
- [x] 403 is not retried (verified with call count assertion)
- [x] All 14 writer tests pass
- [x] Lint, typecheck, and CI checks pass