### PR TITLE
docs: add token permissions link to getting started page

### DIFF
--- a/packages/web/src/content/docs/docs/getting-started.md
+++ b/packages/web/src/content/docs/docs/getting-started.md
@@ -36,6 +36,8 @@ jobs:
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 ```
 
+> **Note:** The `GITHUB_TOKEN` requires specific permissions depending on your setup. See [Token permissions](/docs/guides/configuration/#token-permissions) for details.
+
 Replace `your-org/architecture` with the repository that contains your architecture model. The action clones the model repo automatically — no `actions/checkout` step is needed.
 
 ### 3. Open a pull request


### PR DESCRIPTION
Link to the configuration guide's token permissions section from the workflow example that uses secrets.GITHUB_TOKEN, so users can easily find the required permissions for their setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification to the getting-started guide explaining that GITHUB_TOKEN permissions configuration depends on your setup. This note provides helpful context when configuring GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->