### PR TITLE
ci: auto-merge dependabot PRs for minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: 'build(deps)'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -20,8 +22,13 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    commit-message:
+      prefix: 'build(deps)'
+      prefix-development: 'build(deps-dev)'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: 'ci(deps)'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Auto-merge Dependabot
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: metadata
+
+      - uses: actions/create-github-app-token@v2
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Approve and auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

- Add workflow that approves and enables auto-merge for non-major Dependabot PRs
- Uses `dependabot/fetch-metadata` for semver-type filtering and the existing release GitHub App for authentication
- Add `commit-message` prefixes to `dependabot.yml` so PR titles pass commitlint (`build(deps)`, `build(deps-dev)`, `ci(deps)`)

## Manual step required

**Enable "Allow auto-merge"** in repo settings before this takes effect:
Settings > General > Pull Requests > check "Allow auto-merge"

## How it works

1. Dependabot opens PR
2. `code-check.yml` and `dependabot-auto-merge.yml` trigger in parallel
3. If not a major update: workflow approves PR and enables auto-merge (`--auto --squash`)
4. GitHub waits for the `check` required status to pass before merging
5. Major-version PRs are left for manual review

## Test plan

- [x] Enable "Allow auto-merge" in repo settings
- [x] Wait for next Dependabot run or trigger with `@dependabot rebase`
- [x] Confirm `auto-merge` job runs and shows approval + auto-merge enabled
- [x] Confirm PR merges only after `check` passes
- [x] Verify major-version PRs are NOT auto-merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency update automation with standardized commit message prefixes for better clarity across Docker, npm, and GitHub Actions ecosystems.
  * Implemented automatic approval and merging of non-major Dependabot pull requests to streamline the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->