### PR TITLE
fix: loop HTML sanitization until stable to handle nested tags

### DIFF
--- a/packages/core/src/platforms/__tests__/platform-utils.test.ts
+++ b/packages/core/src/platforms/__tests__/platform-utils.test.ts
@@ -109,6 +109,12 @@ describe('sanitizeErrorMessage', () => {
     expect(result).toContain('Error');
   });
 
+  it('strips nested/malformed HTML tags', () => {
+    const result = sanitizeErrorMessage('<scr<script>ipt>alert(1)</script>');
+    expect(result).not.toMatch(/<[^>]*>/);
+    expect(result).toContain('alert(1)');
+  });
+
   it('truncates sanitized output to 200 characters', () => {
     const longHtml = '<div>' + 'A'.repeat(300) + '</div>';
     const result = sanitizeErrorMessage(longHtml);

--- a/packages/core/src/platforms/platform-utils.ts
+++ b/packages/core/src/platforms/platform-utils.ts
@@ -34,11 +34,13 @@ export function applyDiffTruncation(
 
 export function sanitizeErrorMessage(message: string): string {
   if (/<[a-z/!][^>]*>/i.test(message)) {
-    return message
-      .replace(/<[^>]*>/g, '')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 200);
+    let cleaned = message;
+    let prev: string;
+    do {
+      prev = cleaned;
+      cleaned = cleaned.replace(/<[^>]*>/g, '');
+    } while (cleaned !== prev);
+    return cleaned.replace(/\s+/g, ' ').trim().slice(0, 200);
   }
   return message;
 }


### PR DESCRIPTION
## Summary

- Loop `sanitizeErrorMessage` tag stripping until the output stabilizes, fixing incomplete sanitization of nested/malformed HTML (e.g., `<scr<script>ipt>` surviving a single pass)
- Resolves CodeQL HIGH severity alert for incomplete multi-character sanitization

## Test plan

- [x] New test case for nested/malformed HTML tags (`<scr<script>ipt>alert(1)</script>`)
- [x] All 18 existing `platform-utils` tests pass
- [x] `npm run lint` clean
- [x] `npm run typecheck --workspace=packages/core` clean