### PR TITLE
ci: add explicit permissions to workflows

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -8,6 +8,9 @@ concurrency:
   group: test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -8,6 +8,9 @@ concurrency:
   group: update-cache
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update-cache:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `code-check.yml` and `update-cache.yml` workflows
- Restricts `GITHUB_TOKEN` from default broad permissions to least-privilege read-only access
