### PR TITLE
fix(web): correct broken links in landing page integration section

### DIFF
--- a/packages/web/src/components/integration-section.astro
+++ b/packages/web/src/components/integration-section.astro
@@ -51,7 +51,7 @@ Run `erode check` against local changes to detect
 undeclared dependencies and architecture violations
 before pushing.</code></pre>
         </div>
-        <a href="/docs/guides/claude-code/" class="docs-link">View Claude Code guide &rarr;</a>
+        <a href="/docs/integrations/claude-code/" class="docs-link">View Claude Code guide &rarr;</a>
       </div>
 
       <div class="panel" role="tabpanel" id="panel-cli" aria-labelledby="tab-cli" hidden>
@@ -68,7 +68,7 @@ npx @erode-app/cli check --staged
 <span class="comment"># Compare branch against main before pushing</span>
 npx @erode-app/cli check --branch main</code></pre>
         </div>
-        <a href="/docs/guides/cli-usage/" class="docs-link">View CLI reference &rarr;</a>
+        <a href="/docs/reference/cli-commands/" class="docs-link">View CLI reference &rarr;</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The Claude Code guide link pointed to /docs/guides/claude-code/ (non-existent) instead of /docs/integrations/claude-code/. The CLI reference link pointed to /docs/guides/cli-usage/ instead of /docs/reference/cli-commands/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to new locations for the Claude Code guide and CLI reference resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->