### PR TITLE
docs: add npm publishing info and ci-entry details to contributing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6669,7 +6669,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/packages/web/src/content/docs/docs/contributing.md
+++ b/packages/web/src/content/docs/docs/contributing.md
@@ -17,7 +17,15 @@ Erode is an npm workspace monorepo. The diagram below shows the package structur
 
 ## Packages
 
-- **core**: Analysis engine with AI pipeline, providers, adapters, and platform integrations.
-- **cli**: Interactive terminal interface.
-- **web**: Documentation and landing page.
-- **eslint-config**: Shared ESLint configuration for all packages.
+| Package           | npm               | Description                                                             |
+| ----------------- | ----------------- | ----------------------------------------------------------------------- |
+| **core**          | `@erode-app/core` | Analysis engine. Exports the `erode-ci` binary used by CI integrations. |
+| **cli**           | `@erode-app/cli`  | Interactive terminal interface. Exports the `erode` binary.             |
+| **web**           | private           | Documentation and landing page.                                         |
+| **architecture**  | private           | LikeC4 architecture diagrams.                                           |
+| **eslint-config** | private           | Shared ESLint configuration.                                            |
+
+### CI entry point
+
+GitHub Actions, GitLab CI, and Bitbucket Pipelines all invoke `erode-ci` (core's `dist/ci-entry.js`).
+The entrypoint scripts live at the repo root: `entrypoint.sh`, `entrypoint-gitlab.sh`, `entrypoint-bitbucket.sh`.


### PR DESCRIPTION
## Summary

- Replaced the bullet-list package overview with a table that includes npm package names and clarifies which packages are public vs private
- Added a "CI entry point" section explaining how `erode-ci` is invoked by CI integrations
- Minor `package-lock.json` cleanup

## Test plan

- [ ] Verify the contributing page renders correctly on the docs site
- [ ] Confirm no broken links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide with a structured package reference table for improved clarity
  * Added CI entry point documentation detailing system invocation and available entrypoint scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->