### PR TITLE
feat(core): use gemini-2.5-pro as default advanced model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ ERODE_GITHUB_TOKEN=
 
 # Model overrides — FAST for extraction stages (1, 2), ADVANCED for analysis stages (3, 4)
 # ERODE_GEMINI_FAST_MODEL=gemini-2.5-flash        # Default
-# ERODE_GEMINI_ADVANCED_MODEL=gemini-2.5-flash     # Default (free-tier safe). Paid users: gemini-2.5-pro
+# ERODE_GEMINI_ADVANCED_MODEL=gemini-2.5-pro       # Default
 # ERODE_ANTHROPIC_FAST_MODEL=claude-haiku-4-5-20251001
 # ERODE_ANTHROPIC_ADVANCED_MODEL=claude-sonnet-4-5-20250929
 

--- a/packages/core/schemas/eroderc.schema.json
+++ b/packages/core/schemas/eroderc.schema.json
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "advancedModel": {
-          "default": "gemini-2.5-flash",
+          "default": "gemini-2.5-pro",
           "type": "string"
         }
       },

--- a/packages/core/src/providers/gemini/models.ts
+++ b/packages/core/src/providers/gemini/models.ts
@@ -1,4 +1,4 @@
 export const GEMINI_MODELS = {
   FAST: 'gemini-2.5-flash',
-  ADVANCED: 'gemini-2.5-flash',
+  ADVANCED: 'gemini-2.5-pro',
 } as const;

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -4,6 +4,9 @@ import * as os from 'os';
 import * as dotenv from 'dotenv';
 import { z } from 'zod';
 import { ConfigurationError } from '../errors.js';
+import { ANTHROPIC_MODELS } from '../providers/anthropic/models.js';
+import { GEMINI_MODELS } from '../providers/gemini/models.js';
+import { OPENAI_MODELS } from '../providers/openai/models.js';
 dotenv.config();
 
 export const RC_FILENAME = '.eroderc.json';
@@ -47,20 +50,20 @@ export const ConfigSchema = z.object({
   anthropic: z.object({
     apiKey: z.string().optional(),
     timeout: z.number().int().min(1000).max(300000).default(60000),
-    fastModel: z.string().default('claude-haiku-4-5-20251001'),
-    advancedModel: z.string().default('claude-sonnet-4-5-20250929'),
+    fastModel: z.string().default(ANTHROPIC_MODELS.FAST),
+    advancedModel: z.string().default(ANTHROPIC_MODELS.ADVANCED),
   }),
   gemini: z.object({
     apiKey: z.string().optional(),
     timeout: z.number().int().min(1000).max(300000).default(60000),
-    fastModel: z.string().default('gemini-2.5-flash'),
-    advancedModel: z.string().default('gemini-2.5-flash'),
+    fastModel: z.string().default(GEMINI_MODELS.FAST),
+    advancedModel: z.string().default(GEMINI_MODELS.ADVANCED),
   }),
   openai: z.object({
     apiKey: z.string().optional(),
     timeout: z.number().int().min(1000).max(300000).default(60000),
-    fastModel: z.string().default('gpt-4.1-mini'),
-    advancedModel: z.string().default('gpt-4.1'),
+    fastModel: z.string().default(OPENAI_MODELS.FAST),
+    advancedModel: z.string().default(OPENAI_MODELS.ADVANCED),
   }),
   debug: z.object({
     enabled: z.boolean().default(false),

--- a/packages/web/public/schemas/v0/eroderc.schema.json
+++ b/packages/web/public/schemas/v0/eroderc.schema.json
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "advancedModel": {
-          "default": "gemini-2.5-flash",
+          "default": "gemini-2.5-pro",
           "type": "string"
         }
       },

--- a/packages/web/src/content/docs/docs/how-it-works.md
+++ b/packages/web/src/content/docs/docs/how-it-works.md
@@ -44,7 +44,7 @@ This keeps the analysis stage focused on dependency changes rather than the full
 
 ## Stage 3 -- Analyze
 
-A stronger model (Sonnet for Anthropic, GPT-4.1 for OpenAI, Flash for Gemini) compares the extracted dependency changes against the declared architecture model and produces violation findings, each with:
+A stronger model (Sonnet for Anthropic, GPT-4.1 for OpenAI, Pro for Gemini) compares the extracted dependency changes against the declared architecture model and produces violation findings, each with:
 
 - A **severity level** (high, medium, or low)
 - A description of the drift

--- a/packages/web/src/content/docs/docs/reference/ai-providers.md
+++ b/packages/web/src/content/docs/docs/reference/ai-providers.md
@@ -29,7 +29,7 @@ Each provider uses two model tiers to balance cost and quality:
 | Tier     | Default model      |
 | -------- | ------------------ |
 | Fast     | `gemini-2.5-flash` |
-| Advanced | `gemini-2.5-flash` |
+| Advanced | `gemini-2.5-pro`   |
 
 ### OpenAI
 


### PR DESCRIPTION
The Gemini provider used gemini-2.5-flash for both fast and advanced
tiers, unlike OpenAI and Anthropic which use stronger models for the
analysis stage. Switch the advanced default to gemini-2.5-pro for
better drift analysis quality.

Also consolidate model defaults in config.ts by importing from each
provider's models.ts, eliminating duplicate hardcoded strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the default Gemini advanced model configuration from Flash to Pro across all system configuration files, schema definitions, and configuration settings throughout the platform.

* **Documentation**
  * Updated user documentation, guides, and reference materials to reflect the new Gemini Pro model as the default advanced selection option for Gemini provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->