### PR TITLE
feat(core): add post-patch formatting via LikeC4 SDK

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "@google/genai": "^1.45.0",
     "@octokit/rest": "^22.0.1",
     "dotenv": "^17.2.3",
-    "likec4": "^1.52.0",
+    "likec4": "^1.53.0",
     "minimatch": "^10.2.4",
     "openai": "^6.29.0",
     "zod": "^4.1.13"

--- a/packages/core/schemas/eroderc.schema.json
+++ b/packages/core/schemas/eroderc.schema.json
@@ -80,6 +80,10 @@
               "items": {
                 "type": "string"
               }
+            },
+            "formatAfterPatch": {
+              "default": true,
+              "type": "boolean"
             }
           },
           "additionalProperties": false

--- a/packages/core/src/adapters/base-patcher.ts
+++ b/packages/core/src/adapters/base-patcher.ts
@@ -144,8 +144,17 @@ export abstract class BasePatcher implements ModelPatcher {
 
     // 7. Optional post-processing (e.g., formatting)
     const preFormatContent = finalContent;
-    finalContent = await this.postFormat(finalContent, modelPath, targetFile);
-    const formatted = finalContent !== preFormatContent;
+    let formatted = false;
+    try {
+      const postFormatted = await this.postFormat(finalContent, modelPath, targetFile);
+      formatted = postFormatted !== preFormatContent;
+      finalContent = postFormatted;
+    } catch (error) {
+      this.debugLog(
+        'Post-processing failed; proceeding with unformatted patch',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
 
     // 8. Compute repo-relative path
     const repoRelativePath = this.getRepoRelativePath(targetFile);

--- a/packages/core/src/adapters/base-patcher.ts
+++ b/packages/core/src/adapters/base-patcher.ts
@@ -34,6 +34,10 @@ export abstract class BasePatcher implements ModelPatcher {
     content: string
   ): Promise<DslValidationResult>;
 
+  protected postFormat(content: string, _modelPath: string, _targetFile: string): Promise<string> {
+    return Promise.resolve(content);
+  }
+
   protected debugLog(msg: string, data?: unknown): void {
     if (CONFIG.debug.verbose) {
       console.error(`[${this.formatName}] ${msg}`, data !== undefined ? JSON.stringify(data) : '');
@@ -138,7 +142,12 @@ export abstract class BasePatcher implements ModelPatcher {
       return null;
     }
 
-    // 7. Compute repo-relative path
+    // 7. Optional post-processing (e.g., formatting)
+    const preFormatContent = finalContent;
+    finalContent = await this.postFormat(finalContent, modelPath, targetFile);
+    const formatted = finalContent !== preFormatContent;
+
+    // 8. Compute repo-relative path
     const repoRelativePath = this.getRepoRelativePath(targetFile);
 
     return {
@@ -158,6 +167,7 @@ export abstract class BasePatcher implements ModelPatcher {
             }))
           : undefined,
       validationSkipped: validationSkipped || undefined,
+      formatted: formatted || undefined,
     };
   }
 

--- a/packages/core/src/adapters/likec4/__tests__/dsl-formatter.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/dsl-formatter.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('likec4', () => ({
+  LikeC4: {
+    fromWorkspace: vi.fn(),
+  },
+}));
+
+vi.mock('fs/promises', () => ({
+  mkdtemp: vi.fn().mockResolvedValue('/tmp/erode-likec4-fmt-abc'),
+  cp: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { LikeC4 } from 'likec4';
+import { formatLikeC4Dsl } from '../dsl-formatter.js';
+
+const mockFromWorkspace = vi.mocked(LikeC4.fromWorkspace);
+
+describe('formatLikeC4Dsl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return formatted content on success', async () => {
+    const formattedContent = 'model {\n  a = service\n}\n';
+    const formatMap = new Map([['file:///tmp/erode-likec4-fmt-abc/model.c4', formattedContent]]);
+
+    mockFromWorkspace.mockResolvedValue({
+      format: vi.fn().mockResolvedValue(formatMap),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof LikeC4.fromWorkspace> extends Promise<infer T> ? T : never);
+
+    const result = await formatLikeC4Dsl(
+      '/workspace',
+      '/workspace/model.c4',
+      'model {a = service}'
+    );
+
+    expect(result.formatted).toBe(true);
+    expect(result.content).toBe(formattedContent);
+  });
+
+  it('should return skipped when format method does not exist', async () => {
+    mockFromWorkspace.mockResolvedValue({
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof LikeC4.fromWorkspace> extends Promise<infer T> ? T : never);
+
+    const result = await formatLikeC4Dsl('/workspace', '/workspace/model.c4', 'model {}');
+
+    expect(result.formatted).toBe(false);
+    expect(result.skipped).toBe(true);
+  });
+
+  it('should return skipped when SDK throws', async () => {
+    mockFromWorkspace.mockRejectedValue(new Error('SDK unavailable'));
+
+    const result = await formatLikeC4Dsl('/workspace', '/workspace/model.c4', 'model {}');
+
+    expect(result.formatted).toBe(false);
+    expect(result.skipped).toBe(true);
+  });
+
+  it('should return error when target file not found in format result', async () => {
+    const formatMap = new Map([['file:///tmp/erode-likec4-fmt-abc/other.c4', 'other content']]);
+
+    mockFromWorkspace.mockResolvedValue({
+      format: vi.fn().mockResolvedValue(formatMap),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<typeof LikeC4.fromWorkspace> extends Promise<infer T> ? T : never);
+
+    const result = await formatLikeC4Dsl('/workspace', '/workspace/model.c4', 'model {}');
+
+    expect(result.formatted).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  it('should call dispose even when format throws', async () => {
+    const disposeFn = vi.fn().mockResolvedValue(undefined);
+    mockFromWorkspace.mockResolvedValue({
+      format: vi.fn().mockRejectedValue(new Error('format failed')),
+      dispose: disposeFn,
+    } as unknown as ReturnType<typeof LikeC4.fromWorkspace> extends Promise<infer T> ? T : never);
+
+    const result = await formatLikeC4Dsl('/workspace', '/workspace/model.c4', 'model {}');
+
+    expect(result.formatted).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(disposeFn).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/adapters/likec4/__tests__/patcher-format.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/patcher-format.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LikeC4Patcher } from '../patcher.js';
+import type { StructuredRelationship } from '../../../analysis/analysis-types.js';
+import type { ComponentIndex, ArchitecturalComponent } from '../../architecture-types.js';
+import type { AIProvider } from '../../../providers/ai-provider.js';
+
+vi.mock('fs', async (importOriginal) => ({
+  ...(await importOriginal()),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(() => '/repo'),
+  execFile: vi.fn(),
+}));
+
+vi.mock('../dsl-validator.js', () => ({
+  validateLikeC4Dsl: vi.fn().mockResolvedValue({ valid: true }),
+}));
+
+vi.mock('../dsl-formatter.js', () => ({
+  formatLikeC4Dsl: vi.fn().mockResolvedValue({ formatted: false, skipped: true }),
+}));
+
+import { readFileSync, readdirSync } from 'fs';
+import { validateLikeC4Dsl } from '../dsl-validator.js';
+import { formatLikeC4Dsl } from '../dsl-formatter.js';
+
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockReaddirSync = vi.mocked(readdirSync);
+const mockValidateLikeC4Dsl = vi.mocked(validateLikeC4Dsl);
+const mockFormatLikeC4Dsl = vi.mocked(formatLikeC4Dsl);
+
+function makeComponent(id: string): ArchitecturalComponent {
+  return { id, name: id, tags: [], type: 'service' };
+}
+
+function makeIndex(ids: string[]): ComponentIndex {
+  const byId = new Map(ids.map((id) => [id, makeComponent(id)]));
+  return { byId, byRepository: new Map() };
+}
+
+function makeProvider(): AIProvider {
+  return {
+    extractDependencies: vi.fn(),
+    analyzeDrift: vi.fn(),
+  } as unknown as AIProvider;
+}
+
+const SAMPLE_C4 = `specification {
+  element service
+}
+
+model {
+  customer = service 'Customer'
+  backend = service 'Backend'
+
+  customer -> backend 'Uses API'
+}
+`;
+
+describe('LikeC4Patcher post-format', () => {
+  let patcher: LikeC4Patcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patcher = new LikeC4Patcher();
+    mockValidateLikeC4Dsl.mockResolvedValue({ valid: true });
+  });
+
+  it('should apply post-patch formatting when formatter returns content', async () => {
+    mockReaddirSync.mockReturnValue(['model.c4'] as unknown as ReturnType<typeof readdirSync>);
+    mockReadFileSync.mockReturnValue(SAMPLE_C4);
+
+    const formattedContent = SAMPLE_C4 + "\n  customer -> backend 'Formatted'\n";
+    mockFormatLikeC4Dsl.mockResolvedValue({
+      formatted: true,
+      content: formattedContent,
+    });
+
+    const rels: StructuredRelationship[] = [
+      { source: 'customer', target: 'backend', description: 'New dep' },
+    ];
+
+    const result = await patcher.patch({
+      modelPath: '/model',
+      relationships: rels,
+      existingRelationships: [],
+      componentIndex: makeIndex(['customer', 'backend']),
+      provider: makeProvider(),
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.content).toBe(formattedContent);
+    expect(result.formatted).toBe(true);
+    expect(mockFormatLikeC4Dsl).toHaveBeenCalled();
+  });
+
+  it('should set formatted to undefined when formatting is skipped', async () => {
+    mockReaddirSync.mockReturnValue(['model.c4'] as unknown as ReturnType<typeof readdirSync>);
+    mockReadFileSync.mockReturnValue(SAMPLE_C4);
+    mockFormatLikeC4Dsl.mockResolvedValue({ formatted: false, skipped: true });
+
+    const rels: StructuredRelationship[] = [
+      { source: 'customer', target: 'backend', description: 'New dep' },
+    ];
+
+    const result = await patcher.patch({
+      modelPath: '/model',
+      relationships: rels,
+      existingRelationships: [],
+      componentIndex: makeIndex(['customer', 'backend']),
+      provider: makeProvider(),
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.formatted).toBeUndefined();
+  });
+});

--- a/packages/core/src/adapters/likec4/__tests__/patcher.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/patcher.test.ts
@@ -30,12 +30,10 @@ vi.mock('../dsl-formatter.js', () => ({
 
 import { readFileSync, readdirSync } from 'fs';
 import { validateLikeC4Dsl } from '../dsl-validator.js';
-import { formatLikeC4Dsl } from '../dsl-formatter.js';
 
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockReaddirSync = vi.mocked(readdirSync);
 const mockValidateLikeC4Dsl = vi.mocked(validateLikeC4Dsl);
-const mockFormatLikeC4Dsl = vi.mocked(formatLikeC4Dsl);
 
 function makeComponent(id: string): ArchitecturalComponent {
   return { id, name: id, tags: [], type: 'service' };
@@ -475,57 +473,6 @@ describe('LikeC4Patcher', () => {
 
     expect(gatewayComp?.insertedLines).toHaveLength(1);
     expect(gatewayComp?.insertedLines[0]).toContain("api-gateway = service 'API Gateway'");
-  });
-
-  it('should apply post-patch formatting when formatter returns content', async () => {
-    mockReaddirSync.mockReturnValue(['model.c4'] as unknown as ReturnType<typeof readdirSync>);
-    mockReadFileSync.mockReturnValue(SAMPLE_C4);
-
-    const formattedContent = SAMPLE_C4 + "\n  customer -> backend 'Formatted'\n";
-    mockFormatLikeC4Dsl.mockResolvedValue({
-      formatted: true,
-      content: formattedContent,
-    });
-
-    const rels: StructuredRelationship[] = [
-      { source: 'customer', target: 'backend', description: 'New dep' },
-    ];
-
-    const result = await patcher.patch({
-      modelPath: '/model',
-      relationships: rels,
-      existingRelationships: [],
-      componentIndex: makeIndex(['customer', 'backend']),
-      provider: makeProvider(),
-    });
-
-    expect(result).not.toBeNull();
-    if (!result) return;
-    expect(result.content).toBe(formattedContent);
-    expect(result.formatted).toBe(true);
-    expect(mockFormatLikeC4Dsl).toHaveBeenCalled();
-  });
-
-  it('should set formatted to undefined when formatting is skipped', async () => {
-    mockReaddirSync.mockReturnValue(['model.c4'] as unknown as ReturnType<typeof readdirSync>);
-    mockReadFileSync.mockReturnValue(SAMPLE_C4);
-    mockFormatLikeC4Dsl.mockResolvedValue({ formatted: false, skipped: true });
-
-    const rels: StructuredRelationship[] = [
-      { source: 'customer', target: 'backend', description: 'New dep' },
-    ];
-
-    const result = await patcher.patch({
-      modelPath: '/model',
-      relationships: rels,
-      existingRelationships: [],
-      componentIndex: makeIndex(['customer', 'backend']),
-      provider: makeProvider(),
-    });
-
-    expect(result).not.toBeNull();
-    if (!result) return;
-    expect(result.formatted).toBeUndefined();
   });
 
   it('should produce correct combined output with new component and relationship', async () => {

--- a/packages/core/src/adapters/likec4/__tests__/patcher.test.ts
+++ b/packages/core/src/adapters/likec4/__tests__/patcher.test.ts
@@ -24,12 +24,18 @@ vi.mock('../dsl-validator.js', () => ({
   validateLikeC4Dsl: vi.fn().mockResolvedValue({ valid: true }),
 }));
 
+vi.mock('../dsl-formatter.js', () => ({
+  formatLikeC4Dsl: vi.fn().mockResolvedValue({ formatted: false, skipped: true }),
+}));
+
 import { readFileSync, readdirSync } from 'fs';
 import { validateLikeC4Dsl } from '../dsl-validator.js';
+import { formatLikeC4Dsl } from '../dsl-formatter.js';
 
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockReaddirSync = vi.mocked(readdirSync);
 const mockValidateLikeC4Dsl = vi.mocked(validateLikeC4Dsl);
+const mockFormatLikeC4Dsl = vi.mocked(formatLikeC4Dsl);
 
 function makeComponent(id: string): ArchitecturalComponent {
   return { id, name: id, tags: [], type: 'service' };
@@ -469,6 +475,57 @@ describe('LikeC4Patcher', () => {
 
     expect(gatewayComp?.insertedLines).toHaveLength(1);
     expect(gatewayComp?.insertedLines[0]).toContain("api-gateway = service 'API Gateway'");
+  });
+
+  it('should apply post-patch formatting when formatter returns content', async () => {
+    mockReaddirSync.mockReturnValue(['model.c4'] as unknown as ReturnType<typeof readdirSync>);
+    mockReadFileSync.mockReturnValue(SAMPLE_C4);
+
+    const formattedContent = SAMPLE_C4 + "\n  customer -> backend 'Formatted'\n";
+    mockFormatLikeC4Dsl.mockResolvedValue({
+      formatted: true,
+      content: formattedContent,
+    });
+
+    const rels: StructuredRelationship[] = [
+      { source: 'customer', target: 'backend', description: 'New dep' },
+    ];
+
+    const result = await patcher.patch({
+      modelPath: '/model',
+      relationships: rels,
+      existingRelationships: [],
+      componentIndex: makeIndex(['customer', 'backend']),
+      provider: makeProvider(),
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.content).toBe(formattedContent);
+    expect(result.formatted).toBe(true);
+    expect(mockFormatLikeC4Dsl).toHaveBeenCalled();
+  });
+
+  it('should set formatted to undefined when formatting is skipped', async () => {
+    mockReaddirSync.mockReturnValue(['model.c4'] as unknown as ReturnType<typeof readdirSync>);
+    mockReadFileSync.mockReturnValue(SAMPLE_C4);
+    mockFormatLikeC4Dsl.mockResolvedValue({ formatted: false, skipped: true });
+
+    const rels: StructuredRelationship[] = [
+      { source: 'customer', target: 'backend', description: 'New dep' },
+    ];
+
+    const result = await patcher.patch({
+      modelPath: '/model',
+      relationships: rels,
+      existingRelationships: [],
+      componentIndex: makeIndex(['customer', 'backend']),
+      provider: makeProvider(),
+    });
+
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.formatted).toBeUndefined();
   });
 
   it('should produce correct combined output with new component and relationship', async () => {

--- a/packages/core/src/adapters/likec4/dsl-formatter.ts
+++ b/packages/core/src/adapters/likec4/dsl-formatter.ts
@@ -1,0 +1,43 @@
+import { withTempWorkspaceCopy } from '../dsl-validation.js';
+
+interface FormatResult {
+  formatted: boolean;
+  content?: string;
+  skipped?: boolean;
+  error?: string;
+}
+
+export async function formatLikeC4Dsl(
+  workspacePath: string,
+  targetFile: string,
+  patchedContent: string
+): Promise<FormatResult> {
+  try {
+    return await withTempWorkspaceCopy(
+      workspacePath,
+      targetFile,
+      patchedContent,
+      'erode-likec4-fmt',
+      async (tmpTarget, tmpDir) => {
+        const { LikeC4 } = await import('likec4');
+        const likec4 = await LikeC4.fromWorkspace(tmpDir, { printErrors: false });
+        try {
+          if (typeof likec4.format !== 'function') {
+            return { formatted: false, skipped: true };
+          }
+          const targetUri = `file://${tmpTarget}`;
+          const result = await likec4.format({ documentUris: [targetUri] });
+          const formatted = result.get(targetUri);
+          if (formatted !== undefined) {
+            return { formatted: true, content: formatted };
+          }
+          return { formatted: false, error: 'Target file not found in format result' };
+        } finally {
+          await likec4.dispose();
+        }
+      }
+    );
+  } catch {
+    return { formatted: false, skipped: true };
+  }
+}

--- a/packages/core/src/adapters/likec4/dsl-formatter.ts
+++ b/packages/core/src/adapters/likec4/dsl-formatter.ts
@@ -1,4 +1,6 @@
+import { pathToFileURL } from 'node:url';
 import { withTempWorkspaceCopy } from '../dsl-validation.js';
+import { CONFIG } from '../../utils/config.js';
 
 interface FormatResult {
   formatted: boolean;
@@ -25,7 +27,7 @@ export async function formatLikeC4Dsl(
           if (typeof likec4.format !== 'function') {
             return { formatted: false, skipped: true };
           }
-          const targetUri = `file://${tmpTarget}`;
+          const targetUri = pathToFileURL(tmpTarget).href;
           const result = await likec4.format({ documentUris: [targetUri] });
           const formatted = result.get(targetUri);
           if (formatted !== undefined) {
@@ -37,7 +39,13 @@ export async function formatLikeC4Dsl(
         }
       }
     );
-  } catch {
+  } catch (err) {
+    if (CONFIG.debug.verbose) {
+      console.error(
+        '[formatLikeC4Dsl] Formatting skipped due to error:',
+        err instanceof Error ? err.message : String(err)
+      );
+    }
     return { formatted: false, skipped: true };
   }
 }

--- a/packages/core/src/adapters/likec4/patcher.ts
+++ b/packages/core/src/adapters/likec4/patcher.ts
@@ -2,9 +2,11 @@ import { readFileSync, readdirSync } from 'fs';
 import { join, resolve } from 'path';
 import { BasePatcher } from '../base-patcher.js';
 import { validateLikeC4Dsl } from './dsl-validator.js';
+import { formatLikeC4Dsl } from './dsl-formatter.js';
 import type { StructuredRelationship, NewComponent } from '../../analysis/analysis-types.js';
 import type { ModelRelationship } from '../architecture-types.js';
 import type { DslValidationResult } from '../model-patcher.js';
+import { CONFIG } from '../../utils/config.js';
 
 export class LikeC4Patcher extends BasePatcher {
   protected readonly formatName = 'LikeC4Patcher';
@@ -83,5 +85,27 @@ export class LikeC4Patcher extends BasePatcher {
     content: string
   ): Promise<DslValidationResult> {
     return validateLikeC4Dsl(workspace, file, content);
+  }
+
+  protected override async postFormat(
+    content: string,
+    modelPath: string,
+    targetFile: string
+  ): Promise<string> {
+    if (!CONFIG.adapter.likec4.formatAfterPatch) {
+      this.debugLog('Post-patch formatting disabled by config');
+      return content;
+    }
+    const result = await formatLikeC4Dsl(modelPath, targetFile, content);
+    if (result.formatted && result.content) {
+      this.debugLog('Post-patch formatting applied');
+      return result.content;
+    }
+    if (result.skipped) {
+      this.debugLog('Post-patch formatting skipped (SDK unavailable)');
+    } else if (result.error) {
+      this.debugLog('Post-patch formatting failed', result.error);
+    }
+    return content;
   }
 }

--- a/packages/core/src/adapters/model-patcher.ts
+++ b/packages/core/src/adapters/model-patcher.ts
@@ -34,6 +34,8 @@ export interface PatchResult {
   newComponents?: PatchNewComponent[];
   /** true when DSL validation tooling was unavailable and validation was skipped */
   validationSkipped?: boolean;
+  /** true when post-patch formatting was applied */
+  formatted?: boolean;
 }
 
 export interface DslValidationResult {

--- a/packages/core/src/pipelines/analyze.ts
+++ b/packages/core/src/pipelines/analyze.ts
@@ -282,6 +282,9 @@ export async function runAnalyze(
         if (ctx.patchResult.validationSkipped) {
           p.warn('DSL validation skipped: validation tooling unavailable');
         }
+        if (ctx.patchResult.formatted) {
+          p.info('Patched model formatted with LikeC4 formatter');
+        }
         // Write in-place when --patch without --open-pr
         if (options.patchLocal && !options.openPr && !options.dryRun) {
           await writeFile(ctx.patchResult.absolutePath, ctx.patchResult.content, 'utf8');

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -91,6 +91,7 @@ export const ENV_VAR_NAMES = {
   modelPath: 'ERODE_MODEL_PATH',
   modelRepo: 'ERODE_MODEL_REPO',
   modelRef: 'ERODE_MODEL_REF',
+  likec4FormatAfterPatch: 'ERODE_LIKEC4_FORMAT_AFTER_PATCH',
 } as const;
 
 const ENV_MAP: Record<string, string> = {

--- a/packages/core/src/utils/config.ts
+++ b/packages/core/src/utils/config.ts
@@ -28,6 +28,7 @@ export const ConfigSchema = z.object({
     likec4: z.object({
       excludePaths: z.array(z.string()).default([]),
       excludeTags: z.array(z.string()).default([]),
+      formatAfterPatch: z.boolean().default(true),
     }),
     structurizr: z.object({
       cliPath: z.string().optional(),
@@ -120,6 +121,7 @@ const ENV_MAP: Record<string, string> = {
   ERODE_MODEL_REPO_PR_TOKEN: 'github.modelRepoPrToken',
   ERODE_LIKEC4_EXCLUDE_PATHS: 'adapter.likec4.excludePaths',
   ERODE_LIKEC4_EXCLUDE_TAGS: 'adapter.likec4.excludeTags',
+  ERODE_LIKEC4_FORMAT_AFTER_PATCH: 'adapter.likec4.formatAfterPatch',
   ERODE_STRUCTURIZR_CLI_PATH: 'adapter.structurizr.cliPath',
   ERODE_MAX_FILES_PER_DIFF: 'constraints.maxFilesPerDiff',
   ERODE_MAX_LINES_PER_DIFF: 'constraints.maxLinesPerDiff',
@@ -154,6 +156,7 @@ const COERCE_MAP: Record<string, Coercer> = {
   'openai.timeout': toNumber,
   'adapter.likec4.excludePaths': toStringArray,
   'adapter.likec4.excludeTags': toStringArray,
+  'adapter.likec4.formatAfterPatch': toBoolean,
 };
 
 function setNestedValue(obj: Record<string, unknown>, dotPath: string, value: unknown): void {

--- a/packages/web/public/schemas/v0/eroderc.schema.json
+++ b/packages/web/public/schemas/v0/eroderc.schema.json
@@ -80,6 +80,10 @@
               "items": {
                 "type": "string"
               }
+            },
+            "formatAfterPatch": {
+              "default": true,
+              "type": "boolean"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary

- After the patcher generates DSL and validation passes, format the patched content using the LikeC4 SDK's `format()` API
- Produces cleaner model update PRs that match the project's existing `.c4` style
- Gracefully degrades when SDK `format()` is unavailable (older LikeC4 versions)
- New `formatAfterPatch` config option (default: `true`), configurable via `.eroderc.json` or `ERODE_LIKEC4_FORMAT_AFTER_PATCH` env var

### Verbose output

With `ERODE_VERBOSE=true`, the patcher logs formatting status:

```
... Generating model patch
[LikeC4Patcher] Input relationships [...]
[LikeC4Patcher] Attempting LLM-based patching
[LikeC4Patcher] LLM patch accepted {"valid":true}
[LikeC4Patcher] Post-patch formatting applied
✓ Patch: 1 component(s), 3 line(s)
ℹ Patched model formatted with LikeC4 formatter
✓ Model patched: likec4/model.c4
```

When formatting is unavailable:
```
[LikeC4Patcher] Post-patch formatting skipped (SDK unavailable)
```

## Test plan

- [x] `npm run check:ci` passes (lint, typecheck, format, schema)
- [x] `npm run test` passes (819 tests including 7 new formatter/patcher tests)
- [x] `npm run knip` reports no unused exports
- [x] Manual: run `erode analyze` with `--patch-local` against a LikeC4 workspace, verify formatted output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic LikeC4 DSL formatting after patching (enabled by default).
  * New config option to control formatting: adapter.likec4.formatAfterPatch (env: ERODE_LIKEC4_FORMAT_AFTER_PATCH).
  * Pipeline now reports when a patched model was formatted.

* **Tests**
  * Added tests covering LikeC4 formatter and post-patch formatting behavior.

* **Chores**
  * Updated LikeC4 dependency to v1.53.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->