### PR TITLE
feat(web): publish erode-check skill via agent skills discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,8 @@
     "node_modules/@astrojs/compiler": {
       "version": "2.13.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.8.0",
@@ -336,6 +337,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.2.tgz",
       "integrity": "sha512-7AsrvG4EsXUmJT5uqiXJN4oZqKaY0wc/Ip7C6/zGnShHRVoTAA4jxeYIZ3wqbqA6zv4cnp9qk31vB2m2dUcmfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^7.0.0",
         "@astrojs/mdx": "^5.0.0",
@@ -422,6 +424,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2078,6 +2081,7 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3319,6 +3323,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3379,6 +3384,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3832,6 +3838,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4005,6 +4012,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.5.tgz",
       "integrity": "sha512-AJVw/JlssxUCBFi3Hp4djL8Pt7wUQqStBBawCd8cNGBBM2lBzp/rXGguzt4OcMfW+86fs0hpFwMyopHM2r6d3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
@@ -4505,6 +4513,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4936,6 +4945,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5430,6 +5440,7 @@
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5487,6 +5498,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7256,6 +7268,7 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7841,6 +7854,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
       "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9497,6 +9511,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9568,6 +9583,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10192,6 +10208,7 @@
     "node_modules/rollup": {
       "version": "4.59.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10290,8 +10307,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -11017,6 +11033,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11447,6 +11464,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11555,6 +11573,7 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -12050,6 +12069,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12089,6 +12109,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12365,6 +12386,7 @@
         "@erode-app/eslint-config": "*",
         "eslint": "^10.2.0",
         "eslint-plugin-astro": "^1.6.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.8.3"
       }
     }

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -5,5 +5,7 @@ export default [
   ignores,
   ...createBaseConfig(import.meta.dirname),
   ...eslintPluginAstro.configs.recommended,
-  { ignores: ['astro.config.mjs', '.astro/', 'src/content/', 'public/architecture/'] },
+  {
+    ignores: ['astro.config.mjs', '.astro/', 'src/content/', 'public/architecture/', 'scripts/**'],
+  },
 ];

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,6 +26,7 @@
     "@erode-app/eslint-config": "*",
     "eslint": "^10.2.0",
     "eslint-plugin-astro": "^1.6.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,10 +7,12 @@
   "scripts": {
     "dev": "npm run prebuild:diagrams && astro dev",
     "prebuild:diagrams": "cd ../architecture && npm run build && cd ../web && rm -rf public/architecture && cp -r ../architecture/dist public/architecture",
-    "build": "npm run prebuild:diagrams && astro check && astro build",
+    "generate:skills": "npx tsx scripts/generate-agent-skills.ts",
+    "check:skills": "npx tsx scripts/generate-agent-skills.ts --check",
+    "build": "npm run prebuild:diagrams && npm run generate:skills && astro check && astro build",
     "preview": "astro preview",
     "typecheck": "astro check --minimumFailingSeverity hint",
-    "check:ci": "astro check && astro build",
+    "check:ci": "npm run check:skills && astro check && astro build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/packages/web/public/.well-known/agent-skills/erode-check/SKILL.md
+++ b/packages/web/public/.well-known/agent-skills/erode-check/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: erode-check
+description: >-
+  Use this skill whenever code changes introduce new imports, API calls,
+  database connections, message queues, or service-to-service communication.
+  Also use before any commit or push. Catches undeclared dependencies and
+  architecture violations using Erode.
+---
+
+# Architecture Drift Check
+
+Run `erode check` against local changes to detect undeclared dependencies
+and architecture violations before pushing.
+
+## When to Activate
+
+Run this check proactively:
+
+1. **After adding new integrations** -- run when you write code that
+   introduces new imports, API calls, database connections, message queue
+   producers/consumers, or service-to-service communication
+2. **Before committing** -- run before creating any commit to verify no
+   drift was introduced during the session
+3. **On request** -- run when the user mentions "architecture check",
+   "drift check", or "erode"
+
+Skip this check for changes that cannot introduce new dependencies:
+
+- Documentation-only changes (no code paths affected)
+- Test-only changes (test code is not part of the production architecture)
+- Config/tooling changes like tsconfig, eslint, or prettier (no runtime dependencies)
+- Refactors that modify existing logic without adding external calls
+
+## How to Run
+
+Choose the mode based on git state:
+
+**Unstaged changes exist** (you just wrote code):
+
+```bash
+npx @erode-app/cli check --format json
+```
+
+**Changes are staged** (ready to commit):
+
+```bash
+npx @erode-app/cli check --format json --staged
+```
+
+**Commits exist on the branch** (ready to push):
+
+```bash
+npx @erode-app/cli check --format json --branch main
+```
+
+The model path is read from `.eroderc.json` (`adapter.modelPath`). Pass
+`<model-path>` as a positional argument to override it.
+
+Add `--fail-on-violations` when you want a non-zero exit code on drift.
+
+The repository URL is auto-detected from the git remote. Use `--repo
+<url>` only if auto-detection fails.
+
+## Interpreting Results
+
+Parse the JSON output. The key fields are:
+
+- `status`: `"success"` (no drift), `"violations"` (drift found), or
+  `"error"`
+- `analysis.violations[]`: each violation has `severity` (high, medium,
+  low), `description`, `file`, `line`, and `suggestion`
+- `analysis.summary`: human-readable overview
+- `analysis.modelUpdates`: suggested relationship changes for the
+  architecture model
+- `dependencyChanges[]`: each entry has `type` (added, removed, modified),
+  `dependency`, `file`, and `description` -- use this to explain what
+  dependency changes were detected
+
+### When violations are found
+
+1. **Read each violation** and its suggestion
+2. **Decide the right fix** -- either:
+   - Refactor the code to use the declared dependency path (e.g., call
+     through an API gateway instead of directly)
+   - Or note that the architecture model needs updating (the dependency
+     is intentional but undeclared)
+3. **Tell the user** what you found, the severity, and your recommended
+   fix
+4. **Do not silently suppress violations** -- always surface them
+
+### When no violations are found
+
+Briefly confirm: "Architecture check passed, no undeclared dependencies
+detected."
+
+### When the command fails
+
+If `erode check` exits with an error, read the error message. Common causes:
+the AI provider API key is not set, the model path in `.eroderc.json` does
+not exist, or there is no git remote configured. Report the error to the
+user with the suggested fix from the error message.
+
+## Configuration
+
+The model path and provider are read from `.eroderc.json` at the repository
+root. API keys come from environment variables (`ERODE_GEMINI_API_KEY`,
+`ERODE_OPENAI_API_KEY`, or `ERODE_ANTHROPIC_API_KEY`).

--- a/packages/web/public/.well-known/agent-skills/erode-check/SKILL.md
+++ b/packages/web/public/.well-known/agent-skills/erode-check/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   database connections, message queues, or service-to-service communication.
   Also use before any commit or push. Catches undeclared dependencies and
   architecture violations using Erode.
+allowed-tools: Bash, Read, Glob, Grep
 ---
 
 # Architecture Drift Check

--- a/packages/web/public/.well-known/agent-skills/index.json
+++ b/packages/web/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "erode-check",
+      "type": "skill-md",
+      "description": "Use this skill whenever code changes introduce new imports, API calls, database connections, message queues, or service-to-service communication. Also use before any commit or push. Catches undeclared dependencies and architecture violations using Erode.",
+      "url": "https://erode.dev/.well-known/agent-skills/erode-check/SKILL.md",
+      "digest": "sha256:38d58a62ee88a9fc73284dc60fbeff51ed02a78efcdb39569e160f2a687e7707"
+    }
+  ]
+}

--- a/packages/web/public/.well-known/agent-skills/index.json
+++ b/packages/web/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Use this skill whenever code changes introduce new imports, API calls, database connections, message queues, or service-to-service communication. Also use before any commit or push. Catches undeclared dependencies and architecture violations using Erode.",
       "url": "https://erode.dev/.well-known/agent-skills/erode-check/SKILL.md",
-      "digest": "sha256:38d58a62ee88a9fc73284dc60fbeff51ed02a78efcdb39569e160f2a687e7707"
+      "digest": "sha256:789b70ce9db0b0c5000dad1d0ea6f49e361e07369b2fb3f879d01b1e372e1d14"
     }
   ]
 }

--- a/packages/web/scripts/generate-agent-skills.ts
+++ b/packages/web/scripts/generate-agent-skills.ts
@@ -21,16 +21,20 @@ interface SkillIndex {
   skills: SkillEntry[];
 }
 
-function parseFrontMatter(content: string): { description: string; name: string } | null {
+function parseFrontMatter(
+  content: string
+): { name: string; description: string } | { error: string } {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return null;
+  if (!match) return { error: 'no YAML front matter (missing --- delimiters)' };
 
   const yaml = match[1];
   const nameMatch = yaml.match(/^name:\s*(.+)$/m);
-
-  // Handle multi-line YAML folded scalar (>-) and single-line descriptions
-  const descMatch = yaml.match(/^description:\s*>-?\n((?:\s+.+\n?)+)/m);
   const name = nameMatch?.[1]?.trim();
+  if (!name) return { error: 'missing "name" field in front matter' };
+
+  // Handle YAML folded scalars (> and >-). Literal block scalars (|)
+  // and quoted strings are not supported.
+  const descMatch = yaml.match(/^description:\s*>-?\n((?:\s+.+\n?)+)/m);
 
   let description: string | undefined;
   if (descMatch) {
@@ -44,7 +48,7 @@ function parseFrontMatter(content: string): { description: string; name: string 
     description = singleMatch?.[1]?.trim();
   }
 
-  if (!name || !description) return null;
+  if (!description) return { error: 'missing "description" field in front matter' };
   return { name, description };
 }
 
@@ -54,6 +58,12 @@ function computeDigest(content: string): string {
 }
 
 function discoverSkills(): SkillEntry[] {
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.error(`Skills directory not found: ${SKILLS_DIR}`);
+    console.error('Create it with at least one skill subdirectory containing a SKILL.md file.');
+    process.exit(1);
+  }
+
   const entries: SkillEntry[] = [];
   const dirs = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
 
@@ -64,8 +74,8 @@ function discoverSkills(): SkillEntry[] {
 
     const content = fs.readFileSync(skillPath, 'utf-8');
     const meta = parseFrontMatter(content);
-    if (!meta) {
-      console.warn(`Skipping ${dir.name}: missing or invalid front matter`);
+    if ('error' in meta) {
+      console.warn(`Skipping ${dir.name}: ${meta.error}`);
       continue;
     }
 

--- a/packages/web/scripts/generate-agent-skills.ts
+++ b/packages/web/scripts/generate-agent-skills.ts
@@ -1,0 +1,123 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = path.resolve(__dirname, '../public/.well-known/agent-skills');
+const BASE_URL = 'https://erode.dev/.well-known/agent-skills';
+const SCHEMA_VERSION = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+
+interface SkillEntry {
+  name: string;
+  type: 'skill-md' | 'archive';
+  description: string;
+  url: string;
+  digest: string;
+}
+
+interface SkillIndex {
+  $schema: string;
+  skills: SkillEntry[];
+}
+
+function parseFrontMatter(content: string): { description: string; name: string } | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const yaml = match[1];
+  const nameMatch = yaml.match(/^name:\s*(.+)$/m);
+
+  // Handle multi-line YAML folded scalar (>-) and single-line descriptions
+  const descMatch = yaml.match(/^description:\s*>-?\n((?:\s+.+\n?)+)/m);
+  const name = nameMatch?.[1]?.trim();
+
+  let description: string | undefined;
+  if (descMatch) {
+    description = descMatch[1]
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .join(' ');
+  } else {
+    const singleMatch = yaml.match(/^description:\s*(?!>)(.+)$/m);
+    description = singleMatch?.[1]?.trim();
+  }
+
+  if (!name || !description) return null;
+  return { name, description };
+}
+
+function computeDigest(content: string): string {
+  const hash = crypto.createHash('sha256').update(content, 'utf-8').digest('hex');
+  return `sha256:${hash}`;
+}
+
+function discoverSkills(): SkillEntry[] {
+  const entries: SkillEntry[] = [];
+  const dirs = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
+
+  for (const dir of dirs) {
+    if (!dir.isDirectory()) continue;
+    const skillPath = path.join(SKILLS_DIR, dir.name, 'SKILL.md');
+    if (!fs.existsSync(skillPath)) continue;
+
+    const content = fs.readFileSync(skillPath, 'utf-8');
+    const meta = parseFrontMatter(content);
+    if (!meta) {
+      console.warn(`Skipping ${dir.name}: missing or invalid front matter`);
+      continue;
+    }
+
+    entries.push({
+      name: meta.name,
+      type: 'skill-md',
+      description: meta.description,
+      url: `${BASE_URL}/${dir.name}/SKILL.md`,
+      digest: computeDigest(content),
+    });
+  }
+
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function main() {
+  const skills = discoverSkills();
+
+  if (skills.length === 0) {
+    console.error('No skills found in', SKILLS_DIR);
+    process.exit(1);
+  }
+
+  const index: SkillIndex = {
+    $schema: SCHEMA_VERSION,
+    skills,
+  };
+
+  const json = JSON.stringify(index, null, 2) + '\n';
+  const outPath = path.join(SKILLS_DIR, 'index.json');
+
+  if (process.argv.includes('--check')) {
+    if (!fs.existsSync(outPath)) {
+      console.error(
+        'index.json does not exist. Run `npm run generate:skills --workspace=packages/web`.'
+      );
+      process.exit(1);
+    }
+    const existing = fs.readFileSync(outPath, 'utf-8');
+    if (existing !== json) {
+      console.error('index.json is stale. Run `npm run generate:skills --workspace=packages/web`.');
+      process.exit(1);
+    }
+    console.log('index.json is up-to-date.');
+    return;
+  }
+
+  fs.writeFileSync(outPath, json);
+  console.log(`index.json written with ${skills.length} skill(s):`);
+  for (const skill of skills) {
+    console.log(`  - ${skill.name}: ${skill.digest}`);
+  }
+}
+
+main();

--- a/packages/web/src/content/docs/docs/integrations/claude-code.md
+++ b/packages/web/src/content/docs/docs/integrations/claude-code.md
@@ -18,118 +18,14 @@ the package on first use and caches it for subsequent runs.
 
 ### 1. Create the skill file
 
-Create `.claude/skills/erode-check/SKILL.md` in your repository:
-
-````markdown
----
-name: erode-check
-description: >-
-  Use this skill whenever code changes introduce new imports, API calls,
-  database connections, message queues, or service-to-service communication.
-  Also use before any commit or push. Catches undeclared dependencies and
-  architecture violations using Erode.
-allowed-tools: Bash, Read, Glob, Grep
----
-
-# Architecture Drift Check
-
-Run `erode check` against local changes to detect undeclared dependencies
-and architecture violations before pushing.
-
-## When to Activate
-
-Run this check proactively:
-
-1. **After adding new integrations** -- run when you write code that
-   introduces new imports, API calls, database connections, message queue
-   producers/consumers, or service-to-service communication
-2. **Before committing** -- run before creating any commit to verify no
-   drift was introduced during the session
-3. **On request** -- run when the user mentions "architecture check",
-   "drift check", or "erode"
-
-Skip this check for changes that cannot introduce new dependencies:
-
-- Documentation-only changes (no code paths affected)
-- Test-only changes (test code is not part of the production architecture)
-- Config/tooling changes like tsconfig, eslint, or prettier (no runtime dependencies)
-- Refactors that modify existing logic without adding external calls
-
-## How to Run
-
-Choose the mode based on git state:
-
-**Unstaged changes exist** (you just wrote code):
+Download [`SKILL.md`](https://erode.dev/.well-known/agent-skills/erode-check/SKILL.md)
+and save it to `.claude/skills/erode-check/SKILL.md` in your repository:
 
 ```bash
-npx @erode-app/cli check --format json
+mkdir -p .claude/skills/erode-check
+curl -o .claude/skills/erode-check/SKILL.md \
+  https://erode.dev/.well-known/agent-skills/erode-check/SKILL.md
 ```
-
-**Changes are staged** (ready to commit):
-
-```bash
-npx @erode-app/cli check --format json --staged
-```
-
-**Commits exist on the branch** (ready to push):
-
-```bash
-npx @erode-app/cli check --format json --branch main
-```
-
-The model path is read from `.eroderc.json` (`adapter.modelPath`). Pass
-`<model-path>` as a positional argument to override it.
-
-Add `--fail-on-violations` when you want a non-zero exit code on drift.
-
-The repository URL is auto-detected from the git remote. Use `--repo
-<url>` only if auto-detection fails.
-
-## Interpreting Results
-
-Parse the JSON output. The key fields are:
-
-- `status`: `"success"` (no drift), `"violations"` (drift found), or
-  `"error"`
-- `analysis.violations[]`: each violation has `severity` (high, medium,
-  low), `description`, `file`, `line`, and `suggestion`
-- `analysis.summary`: human-readable overview
-- `analysis.modelUpdates`: suggested relationship changes for the
-  architecture model
-- `dependencyChanges[]`: each entry has `type` (added, removed, modified),
-  `dependency`, `file`, and `description` -- use this to explain what
-  dependency changes were detected
-
-### When violations are found
-
-1. **Read each violation** and its suggestion
-2. **Decide the right fix** -- either:
-   - Refactor the code to use the declared dependency path (e.g., call
-     through an API gateway instead of directly)
-   - Or note that the architecture model needs updating (the dependency
-     is intentional but undeclared)
-3. **Tell the user** what you found, the severity, and your recommended
-   fix
-4. **Do not silently suppress violations** -- always surface them
-
-### When no violations are found
-
-Briefly confirm: "Architecture check passed, no undeclared dependencies
-detected."
-
-### When the command fails
-
-If `erode check` exits with an error, read the error message. Common causes:
-the AI provider API key is not set, the model path in `.eroderc.json` does
-not exist, or there is no git remote configured. Report the error to the
-user with the suggested fix from the error message.
-
-## Configuration
-
-The model path and provider are read from `.eroderc.json` at the repository
-root. API keys come from environment variables (`ERODE_GEMINI_API_KEY`,
-`ERODE_OPENAI_API_KEY`, or `ERODE_ANTHROPIC_API_KEY`).
-````
 
 ### 2. Add a project config (if you don't have one)
 

--- a/packages/web/src/content/docs/docs/integrations/claude-code.md
+++ b/packages/web/src/content/docs/docs/integrations/claude-code.md
@@ -195,6 +195,14 @@ This runs `erode check` after every edit to a source file and feeds the output b
 The hook approach runs on every edit, which triggers multiple AI API calls each time. This adds up quickly during active sessions. The skill approach above is recommended for most users. It only runs when Claude Code judges that new integrations were introduced.
 :::
 
+## Agent Skills Discovery
+
+The erode-check skill is published at
+[`erode.dev/.well-known/agent-skills/`](https://erode.dev/.well-known/agent-skills/index.json)
+following the [Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc).
+Agents that support the protocol can discover and load the skill automatically
+without manual setup.
+
 ## What's next
 
 - [CLI Commands](/docs/reference/cli-commands/): all `erode check` flags and options

--- a/packages/web/src/content/docs/docs/integrations/claude-code.md
+++ b/packages/web/src/content/docs/docs/integrations/claude-code.md
@@ -91,7 +91,7 @@ This runs `erode check` after every edit to a source file and feeds the output b
 The hook approach runs on every edit, which triggers multiple AI API calls each time. This adds up quickly during active sessions. The skill approach above is recommended for most users. It only runs when Claude Code judges that new integrations were introduced.
 :::
 
-## Agent Skills Discovery
+## Agent skills discovery
 
 The erode-check skill is published at
 [`erode.dev/.well-known/agent-skills/`](https://erode.dev/.well-known/agent-skills/index.json)


### PR DESCRIPTION
## Summary

- Implements the [Cloudflare Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc) (v0.2.0) for the erode-check skill
- After deploy, agents can discover erode at `erode.dev/.well-known/agent-skills/index.json`
- Adds a build script (`generate-agent-skills.ts`) that computes SHA-256 digests and generates the discovery index, with `--check` mode for CI

## Changes

- `packages/web/public/.well-known/agent-skills/erode-check/SKILL.md` -- published skill (same as docs, without `allowed-tools`)
- `packages/web/public/.well-known/agent-skills/index.json` -- generated discovery index
- `packages/web/scripts/generate-agent-skills.ts` -- build script with `--check` mode
- `packages/web/package.json` -- `generate:skills` and `check:skills` scripts wired into `build` and `check:ci`
- `packages/web/eslint.config.mjs` -- ignore `scripts/**` (matches core pattern)
- `packages/web/src/content/docs/docs/integrations/claude-code.md` -- documents the discovery endpoint

## Test plan

- [x] `npm run generate:skills` writes correct `index.json` with valid SHA-256 digest
- [x] `npm run check:skills` exits 0 when up-to-date, exits 1 when stale or missing
- [x] `npm run check:ci` passes (includes `check:skills`)
- [x] Astro build produces `.well-known/` files in `dist/`
- [x] Preview server serves `index.json` (200, `application/json`) and `SKILL.md` (200, `text/markdown`)
- [x] Lint, format, typecheck, knip, markdown lint all clean
- [x] After deploy: `curl https://erode.dev/.well-known/agent-skills/index.json` returns the index