### PR TITLE
feat: update default AI models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,12 @@ ERODE_GITHUB_TOKEN=
 # ERODE_GITLAB_BASE_URL=https://gitlab.com
 
 # Model overrides — FAST for extraction stages (1, 2), ADVANCED for analysis stages (3, 4)
-# ERODE_GEMINI_FAST_MODEL=gemini-2.5-flash        # Default
-# ERODE_GEMINI_ADVANCED_MODEL=gemini-2.5-pro       # Default
-# ERODE_OPENAI_FAST_MODEL=gpt-5-mini               # Default
-# ERODE_OPENAI_ADVANCED_MODEL=gpt-5                # Default
+# ERODE_GEMINI_FAST_MODEL=gemini-3.5-flash-lite     # Default
+# ERODE_GEMINI_ADVANCED_MODEL=gemini-3.6-flash      # Default
+# ERODE_OPENAI_FAST_MODEL=gpt-5.6-luna              # Default
+# ERODE_OPENAI_ADVANCED_MODEL=gpt-5.6-sol           # Default
 # ERODE_ANTHROPIC_FAST_MODEL=claude-haiku-4-5
-# ERODE_ANTHROPIC_ADVANCED_MODEL=claude-sonnet-4-6
+# ERODE_ANTHROPIC_ADVANCED_MODEL=claude-sonnet-5
 
 # Architecture model format
 # ERODE_MODEL_FORMAT=likec4

--- a/packages/core/schemas/eroderc.schema.json
+++ b/packages/core/schemas/eroderc.schema.json
@@ -168,7 +168,7 @@
           "type": "string"
         },
         "advancedModel": {
-          "default": "claude-sonnet-4-6",
+          "default": "claude-sonnet-5",
           "type": "string"
         }
       },
@@ -187,11 +187,11 @@
           "maximum": 300000
         },
         "fastModel": {
-          "default": "gemini-2.5-flash",
+          "default": "gemini-3.5-flash-lite",
           "type": "string"
         },
         "advancedModel": {
-          "default": "gemini-2.5-pro",
+          "default": "gemini-3.6-flash",
           "type": "string"
         }
       },
@@ -210,11 +210,11 @@
           "maximum": 300000
         },
         "fastModel": {
-          "default": "gpt-5-mini",
+          "default": "gpt-5.6-luna",
           "type": "string"
         },
         "advancedModel": {
-          "default": "gpt-5",
+          "default": "gpt-5.6-sol",
           "type": "string"
         }
       },

--- a/packages/core/src/adapters/structurizr/__tests__/integration.test.ts
+++ b/packages/core/src/adapters/structurizr/__tests__/integration.test.ts
@@ -80,7 +80,7 @@ describe('StructurizrAdapter Integration', () => {
       await expect(dirAdapter.loadFromPath(tmp)).rejects.not.toThrow(
         /No workspace file found in directory/
       );
-    });
+    }, 10_000);
 
     it('should throw when directory has no workspace file', async () => {
       const tmp = mkdtempSync(path.join(tmpdir(), 'erode-structurizr-'));

--- a/packages/core/src/providers/anthropic/__tests__/provider.test.ts
+++ b/packages/core/src/providers/anthropic/__tests__/provider.test.ts
@@ -222,7 +222,7 @@ describe('AnthropicProvider', () => {
       expect(result.dependencyChanges).toBe(data.dependencies);
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-5',
           max_tokens: 8192,
         })
       );

--- a/packages/core/src/providers/anthropic/models.ts
+++ b/packages/core/src/providers/anthropic/models.ts
@@ -1,4 +1,4 @@
 export const ANTHROPIC_MODELS = {
   FAST: 'claude-haiku-4-5',
-  ADVANCED: 'claude-sonnet-4-6',
+  ADVANCED: 'claude-sonnet-5',
 } as const;

--- a/packages/core/src/providers/gemini/__tests__/provider.test.ts
+++ b/packages/core/src/providers/gemini/__tests__/provider.test.ts
@@ -128,8 +128,8 @@ describe('GeminiProvider', () => {
       expect(result).toBe('comp.backend');
       expect(mockGenerateContent).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gemini-2.5-flash',
-          config: { maxOutputTokens: 1500, thinkingConfig: { thinkingBudget: 0 } },
+          model: 'gemini-3.5-flash-lite',
+          config: { maxOutputTokens: 1500, thinkingConfig: { thinkingLevel: 'LOW' } },
         })
       );
     });
@@ -190,8 +190,8 @@ describe('GeminiProvider', () => {
       expect(result.summary).toBe('Added Redis dependency');
       expect(mockGenerateContent).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gemini-2.5-flash',
-          config: { maxOutputTokens: 1500, thinkingConfig: { thinkingBudget: 0 } },
+          model: 'gemini-3.5-flash-lite',
+          config: { maxOutputTokens: 1500, thinkingConfig: { thinkingLevel: 'LOW' } },
         })
       );
     });
@@ -243,15 +243,15 @@ describe('GeminiProvider', () => {
       expect(result.dependencyChanges).toBe(data.dependencies);
       expect(mockGenerateContent).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gemini-2.5-pro',
-          config: { maxOutputTokens: 6000, thinkingConfig: { thinkingBudget: -1 } },
+          model: 'gemini-3.6-flash',
+          config: { maxOutputTokens: 6000, thinkingConfig: { thinkingLevel: 'LOW' } },
         })
       );
     });
   });
 
   describe('patchModel', () => {
-    it('should use 2.5 Flash thinking budgets and dynamic output headroom for patching', async () => {
+    it('should use fast model thinking level and dynamic output headroom for patching', async () => {
       const patchedContent = 'model {\n  comp.a -> comp.b\n}\n';
       mockGenerateContent.mockResolvedValueOnce({
         text: patchedContent,
@@ -264,8 +264,8 @@ describe('GeminiProvider', () => {
 
       expect(mockGenerateContent).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gemini-2.5-flash',
-          config: { maxOutputTokens: 4096, thinkingConfig: { thinkingBudget: -1 } },
+          model: 'gemini-3.5-flash-lite',
+          config: { maxOutputTokens: 4096, thinkingConfig: { thinkingLevel: 'MEDIUM' } },
         })
       );
     });

--- a/packages/core/src/providers/gemini/models.ts
+++ b/packages/core/src/providers/gemini/models.ts
@@ -1,4 +1,4 @@
 export const GEMINI_MODELS = {
-  FAST: 'gemini-2.5-flash',
-  ADVANCED: 'gemini-2.5-pro',
+  FAST: 'gemini-3.5-flash-lite',
+  ADVANCED: 'gemini-3.6-flash',
 } as const;

--- a/packages/core/src/providers/openai/__tests__/provider.test.ts
+++ b/packages/core/src/providers/openai/__tests__/provider.test.ts
@@ -142,7 +142,7 @@ describe('OpenAIProvider', () => {
       expect(result).toBe('comp.backend');
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-5-mini',
+          model: 'gpt-5.6-luna',
           max_output_tokens: 1500,
           reasoning: { effort: 'low' },
         })
@@ -226,7 +226,7 @@ describe('OpenAIProvider', () => {
       expect(result.summary).toBe('Added Redis dependency');
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-5-mini',
+          model: 'gpt-5.6-luna',
           max_output_tokens: 1500,
           reasoning: { effort: 'low' },
         })
@@ -272,7 +272,7 @@ describe('OpenAIProvider', () => {
       expect(result.dependencyChanges).toBe(data.dependencies);
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-5',
+          model: 'gpt-5.6-sol',
           max_output_tokens: 10000,
           reasoning: { effort: 'low' },
         })
@@ -430,7 +430,7 @@ describe('OpenAIProvider', () => {
       expect(mockCreate).toHaveBeenCalled();
       const callArg = mockCreate.mock.calls[0]?.[0] as
         { max_output_tokens?: number; model?: string; reasoning?: { effort?: string } } | undefined;
-      expect(callArg?.model).toBe('gpt-5-mini');
+      expect(callArg?.model).toBe('gpt-5.6-luna');
       expect(callArg?.max_output_tokens).toBe(6000);
       expect(callArg?.reasoning?.effort).toBe('medium');
     });

--- a/packages/core/src/providers/openai/models.ts
+++ b/packages/core/src/providers/openai/models.ts
@@ -1,4 +1,4 @@
 export const OPENAI_MODELS = {
-  FAST: 'gpt-5-mini',
-  ADVANCED: 'gpt-5',
+  FAST: 'gpt-5.6-luna',
+  ADVANCED: 'gpt-5.6-sol',
 } as const;

--- a/packages/web/public/schemas/v0/eroderc.schema.json
+++ b/packages/web/public/schemas/v0/eroderc.schema.json
@@ -168,7 +168,7 @@
           "type": "string"
         },
         "advancedModel": {
-          "default": "claude-sonnet-4-6",
+          "default": "claude-sonnet-5",
           "type": "string"
         }
       },
@@ -187,11 +187,11 @@
           "maximum": 300000
         },
         "fastModel": {
-          "default": "gemini-2.5-flash",
+          "default": "gemini-3.5-flash-lite",
           "type": "string"
         },
         "advancedModel": {
-          "default": "gemini-2.5-pro",
+          "default": "gemini-3.6-flash",
           "type": "string"
         }
       },
@@ -210,11 +210,11 @@
           "maximum": 300000
         },
         "fastModel": {
-          "default": "gpt-5-mini",
+          "default": "gpt-5.6-luna",
           "type": "string"
         },
         "advancedModel": {
-          "default": "gpt-5",
+          "default": "gpt-5.6-sol",
           "type": "string"
         }
       },

--- a/packages/web/src/content/docs/docs/reference/ai-providers.md
+++ b/packages/web/src/content/docs/docs/reference/ai-providers.md
@@ -26,24 +26,24 @@ Each provider uses two model tiers to balance cost and quality:
 
 ### Gemini
 
-| Tier     | Default model      |
-| -------- | ------------------ |
-| Fast     | `gemini-2.5-flash` |
-| Advanced | `gemini-2.5-pro`   |
+| Tier     | Default model           |
+| -------- | ----------------------- |
+| Fast     | `gemini-3.5-flash-lite` |
+| Advanced | `gemini-3.6-flash`      |
 
 ### OpenAI
 
-| Tier     | Default model |
-| -------- | ------------- |
-| Fast     | `gpt-5-mini`  |
-| Advanced | `gpt-5`       |
+| Tier     | Default model  |
+| -------- | -------------- |
+| Fast     | `gpt-5.6-luna` |
+| Advanced | `gpt-5.6-sol`  |
 
 ### Anthropic (experimental)
 
-| Tier     | Default model       |
-| -------- | ------------------- |
-| Fast     | `claude-haiku-4-5`  |
-| Advanced | `claude-sonnet-4-6` |
+| Tier     | Default model      |
+| -------- | ------------------ |
+| Fast     | `claude-haiku-4-5` |
+| Advanced | `claude-sonnet-5`  |
 
 :::caution
 Anthropic support is experimental and may not produce consistent results across all codebases. Use Gemini or OpenAI for production workflows.


### PR DESCRIPTION
## Summary

- update stable fast and advanced defaults for Gemini, OpenAI, and Anthropic
- sync provider tests, schemas, environment examples, and documentation
- remove an empty test placeholder and stabilize a Structurizr integration timeout

## Verification

- core and web CI checks
- 836 core tests
- Markdown lint and commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated default AI models for Gemini, OpenAI, and Anthropic providers.
  - Gemini now uses newer fast and advanced models.
  - OpenAI now uses updated fast and advanced models.
  - Anthropic advanced analysis now uses Claude Sonnet 5.

- **Documentation**
  - Updated AI provider reference documentation and configuration schemas to reflect the latest default model selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->